### PR TITLE
화면이 작은 모바일 환경에서 팝업창이 잘리는 현상 보완

### DIFF
--- a/src/css/tui-editor.css
+++ b/src/css/tui-editor.css
@@ -725,3 +725,13 @@
     width: 100px;
     height: 100px;
 }
+
+@media screen and (max-width: 480px) {
+    .tui-popup-wrapper {
+        max-width: 300px;
+    }
+
+    .tui-editor-popup {
+        margin-left: -150px;
+    }
+}


### PR DESCRIPTION
.tui-popup-wrapper 에서 width 값이 500으로 고정되어있어서 아이폰5S 정도의 화면에서는 OK버튼이 보이지 않습니다.