### PR TITLE
Fix: Do not apply font-family to entire .tui-editor-contents class

### DIFF
--- a/src/css/tui-editor-contents.css
+++ b/src/css/tui-editor-contents.css
@@ -4,7 +4,6 @@
 * @author NHN Ent. FE Development Lab <dl_javascript@nhnent.com>
 */
 
-.tui-editor-contents,
 .CodeMirror {
     font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }


### PR DESCRIPTION
fix: font family to the .tui-editor-contents class container overrides the font contained within the editor