### PR TITLE
Remove front family from tui-editor-contents

### DIFF
--- a/src/css/tui-editor-contents.css
+++ b/src/css/tui-editor-contents.css
@@ -4,7 +4,6 @@
 * @author NHN Ent. FE Development Lab <dl_javascript@nhnent.com>
 */
 
-.tui-editor-contents,
 .CodeMirror {
     font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }


### PR DESCRIPTION
Unnecessarily applying font family to `.tui-editor-contents` css class

#52 