### PR TITLE
feat: hide mode switch tab bar (close #54)

### DIFF
--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -117,6 +117,7 @@ class ToastUIEditor {
         * @param {string[]} options.codeBlockLanguages - supported code block languages to be listed
         * @param {boolean} [options.usageStatistics=true] - send hostname to google analytics
         * @param {object[]} [options.toolbarItems] - toolbar items
+        * @param {boolean} options.hideModeSwitch - hide mode switch tab bar
     */
   constructor(options) {
     this.options = $.extend({
@@ -147,7 +148,8 @@ class ToastUIEditor {
         'divider',
         'code',
         'codeblock'
-      ]
+      ],
+      hideModeSwitch: false
     }, options);
 
     this.eventManager = new EventManager();

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -117,7 +117,7 @@ class ToastUIEditor {
         * @param {string[]} options.codeBlockLanguages - supported code block languages to be listed
         * @param {boolean} [options.usageStatistics=true] - send hostname to google analytics
         * @param {object[]} [options.toolbarItems] - toolbar items
-        * @param {boolean} options.hideModeSwitch - hide mode switch tab bar
+        * @param {boolean} [options.hideModeSwitch=false] - hide mode switch tab bar
     */
   constructor(options) {
     this.options = $.extend({

--- a/src/js/ui/defaultUI.js
+++ b/src/js/ui/defaultUI.js
@@ -105,6 +105,14 @@ class DefaultUI {
   _markdownTab;
 
   /**
+   * mode switch instance
+   * @memberof DefaultUI
+   * @private
+   * @type {ModeSwitch}
+   */
+  _modeSwitch;
+
+  /**
    * popup instances
    * @memberof DefaultUI
    * @private
@@ -127,7 +135,8 @@ class DefaultUI {
 
   _init({
     el: container,
-    toolbarItems
+    toolbarItems,
+    hideModeSwitch
   }) {
     this.$el = $(CONTAINER_TEMPLATE).appendTo(container);
     this._container = container;
@@ -135,7 +144,7 @@ class DefaultUI {
     this._editorSection.appendChild(this._editor.layout.getEditorEl().get(0));
 
     this._initToolbar(this._editor.eventManager, toolbarItems);
-    this._initModeSwitch();
+    this._initModeSwitch(hideModeSwitch);
 
     this._initPopupAddLink();
     this._initPopupAddImage();
@@ -161,9 +170,14 @@ class DefaultUI {
     this.$el.find(`.${CLASS_TOOLBAR}`).append(toolbar.$el);
   }
 
-  _initModeSwitch() {
-    const modeSwitch = new ModeSwitch(this._initialEditType === 'markdown' ? ModeSwitch.TYPE.MARKDOWN : ModeSwitch.TYPE.WYSIWYG);
-    this.$el.find(`.${CLASS_MODE_SWITCH}`).append(modeSwitch.$el);
+  _initModeSwitch(hideModeSwitch) {
+    const modeSwitchTabBar = this.$el.find(`.${CLASS_MODE_SWITCH}`);
+    const modeSwitch = new ModeSwitch(modeSwitchTabBar, this._initialEditType === 'markdown' ? ModeSwitch.TYPE.MARKDOWN : ModeSwitch.TYPE.WYSIWYG);
+    this._modeSwitch = modeSwitch;
+
+    if (hideModeSwitch) {
+      modeSwitch.hide();
+    }
 
     modeSwitch.on('modeSwitched', (ev, type) => this._editor.changeMode(type));
   }
@@ -281,6 +295,15 @@ class DefaultUI {
   setToolbar(toolbar) {
     this._toolbar.destroy();
     this._toolbar = toolbar;
+  }
+
+  /**
+   * get mode switch instance
+   * @memberof DefaultUI
+   * @returns {ModeSwitch} - mode switch instance
+   */
+  getModeSwitch() {
+    return this._modeSwitch;
   }
 
   /**

--- a/src/js/ui/defaultUI.js
+++ b/src/js/ui/defaultUI.js
@@ -172,7 +172,8 @@ class DefaultUI {
 
   _initModeSwitch(hideModeSwitch) {
     const modeSwitchTabBar = this.$el.find(`.${CLASS_MODE_SWITCH}`);
-    const modeSwitch = new ModeSwitch(modeSwitchTabBar, this._initialEditType === 'markdown' ? ModeSwitch.TYPE.MARKDOWN : ModeSwitch.TYPE.WYSIWYG);
+    const editType = this._initialEditType === 'markdown' ? ModeSwitch.TYPE.MARKDOWN : ModeSwitch.TYPE.WYSIWYG;
+    const modeSwitch = new ModeSwitch(modeSwitchTabBar, editType);
     this._modeSwitch = modeSwitch;
 
     if (hideModeSwitch) {

--- a/src/js/ui/modeSwitch.js
+++ b/src/js/ui/modeSwitch.js
@@ -18,31 +18,96 @@ const WYSIWYG = 'wysiwyg';
  */
 class ModeSwitch extends UIController {
   /**
+   * mode switch type
+   * @memberof ModeSwitch
+   * @property {string} MARKDOWN - Markdown
+   * @property {string} WYSIWYG - WYSIWYG
+   * @static
+   */
+  static TYPE = {
+    MARKDOWN,
+    WYSIWYG
+  }
+
+  /**
+   * mode switch buttons
+   * @memberof ModeSwitch
+   * @type {Object}
+   * @private
+   */
+  _buttons = {};
+
+  /**
+   * current mode
+   * @memberof ModeSwitch
+   * @type {String}
+   * @private
+   */
+  _type
+
+  /**
+   * root element
+   * @type {jQuery}
+   */
+  _$rootElement
+
+  /**
    * Creates an instance of ModeSwitch.
+   * @param {jQuery} $rootElement - root jquery element
    * @param {string} initialType - initial type of editor
    * @memberof ModeSwitch
    */
-  constructor(initialType) {
+  constructor($rootElement, initialType) {
     super({
       tagName: 'div',
       className: 'te-mode-switch'
     });
 
-    this._render();
+    this._render($rootElement);
     this._switchType(util.isExisty(initialType) ? initialType : MARKDOWN);
   }
 
-  _render() {
-    this.buttons = {};
-    this.buttons.$markdown
+  /**
+   * is the switch tab bar showing
+   * @returns {Boolean} - showing status
+   */
+  isShowing() {
+    return this._$rootElement.css('display') === 'block';
+  }
+
+  /**
+   * show switch tab bar
+   * @memberof ModeSwitch
+   */
+  show() {
+    this._$rootElement.css('display', 'block');
+  }
+
+  /**
+   * hide switch tab bar
+   * @memberof ModeSwitch
+   */
+  hide() {
+    this._$rootElement.css('display', 'none');
+  }
+
+  _render($rootElement) {
+    this._buttons.$markdown
             = $(`<button class="te-switch-button markdown" type="button">${i18n.get('Markdown')}</button>`);
-    this.buttons.$wysiwyg
+    this._buttons.$wysiwyg
             = $(`<button class="te-switch-button wysiwyg" type="button">${i18n.get('WYSIWYG')}</button>`);
-    this.$el.append(this.buttons.$markdown);
-    this.$el.append(this.buttons.$wysiwyg);
+    this.$el.append(this._buttons.$markdown);
+    this.$el.append(this._buttons.$wysiwyg);
+
+    if ($rootElement) {
+      $rootElement.append(this.$el);
+      this._$rootElement = $rootElement;
+    }
 
     this.on('click .markdown', this._changeMarkdown.bind(this));
     this.on('click .wysiwyg', this._changeWysiwyg.bind(this));
+
+    this.show();
   }
 
   _changeMarkdown() {
@@ -54,31 +119,20 @@ class ModeSwitch extends UIController {
   }
 
   _setActiveButton(type) {
-    this.buttons.$markdown.removeClass('active');
-    this.buttons.$wysiwyg.removeClass('active');
-    this.buttons[`$${type}`].addClass('active');
+    this._buttons.$markdown.removeClass('active');
+    this._buttons.$wysiwyg.removeClass('active');
+    this._buttons[`$${type}`].addClass('active');
   }
 
   _switchType(type) {
-    if (this.type === type) {
+    if (this._type === type) {
       return;
     }
 
-    this.type = type;
+    this._type = type;
     this._setActiveButton(type);
-    this.trigger('modeSwitched', this.type);
+    this.trigger('modeSwitched', this._type);
   }
 }
-
-/**
- * @static
- * @memberof ModeSwitch
- * @property {string} MARKDOWN - markdown
- * @property {string} WYSIWYG - wysiwyg
- */
-ModeSwitch.TYPE = {
-  MARKDOWN,
-  WYSIWYG
-};
 
 export default ModeSwitch;

--- a/src/js/ui/modeSwitch.js
+++ b/src/js/ui/modeSwitch.js
@@ -27,7 +27,7 @@ class ModeSwitch extends UIController {
   static TYPE = {
     MARKDOWN,
     WYSIWYG
-  }
+  };
 
   /**
    * mode switch buttons
@@ -43,13 +43,13 @@ class ModeSwitch extends UIController {
    * @type {String}
    * @private
    */
-  _type
+  _type;
 
   /**
    * root element
    * @type {jQuery}
    */
-  _$rootElement
+  _$rootElement;
 
   /**
    * Creates an instance of ModeSwitch.
@@ -68,10 +68,10 @@ class ModeSwitch extends UIController {
   }
 
   /**
-   * is the switch tab bar showing
+   * is the switch tab bar shown
    * @returns {Boolean} - showing status
    */
-  isShowing() {
+  isShown() {
     return this._$rootElement.css('display') === 'block';
   }
 

--- a/test/editor.spec.js
+++ b/test/editor.spec.js
@@ -367,5 +367,26 @@ describe('Editor', () => {
         expect(toolbarItems[3].getName()).toBe('testItem');
       });
     });
+
+    describe('hideModeSwitch', () => {
+      it('should hide mode switch if the option value is true', () => {
+        editor = new Editor({
+          el: container,
+          hideModeSwitch: true
+        });
+
+        const modeSwitch = editor.getUI().getModeSwitch();
+        expect(modeSwitch.isShowing()).toBe(false);
+      });
+
+      it('should hide mode switch if the option value is true', () => {
+        editor = new Editor({
+          el: container
+        });
+
+        const modeSwitch = editor.getUI().getModeSwitch();
+        expect(modeSwitch.isShowing()).toBe(true);
+      });
+    });
   });
 });

--- a/test/editor.spec.js
+++ b/test/editor.spec.js
@@ -376,7 +376,7 @@ describe('Editor', () => {
         });
 
         const modeSwitch = editor.getUI().getModeSwitch();
-        expect(modeSwitch.isShowing()).toBe(false);
+        expect(modeSwitch.isShown()).toBe(false);
       });
 
       it('should hide mode switch if the option value is true', () => {
@@ -385,7 +385,7 @@ describe('Editor', () => {
         });
 
         const modeSwitch = editor.getUI().getModeSwitch();
-        expect(modeSwitch.isShowing()).toBe(true);
+        expect(modeSwitch.isShown()).toBe(true);
       });
     });
   });

--- a/test/ui/defaultUI.spec.js
+++ b/test/ui/defaultUI.spec.js
@@ -5,6 +5,7 @@
 import ToastUIEditor from '../../src/js/editor';
 import DefaultUI from '../../src/js/ui/defaultUI';
 import Toolbar from '../../src/js/ui/toolbar';
+import ModeSwitch from '../../src/js/ui/modeSwitch';
 
 describe('DeafultUI', () => {
   let container, editor, defaultUI;
@@ -26,13 +27,19 @@ describe('DeafultUI', () => {
     editor.remove();
   });
 
-  describe('getToolbar()', () => {
-    it('should return Toolbar instance', () => {
+  describe('getToolbar', () => {
+    it('should return the Toolbar instance', () => {
       expect(defaultUI.getToolbar() instanceof Toolbar).toBe(true);
     });
   });
 
-  describe('setToolbar()', () => {
+  describe('getModeSwitch', () => {
+    it('should return the ModeSwitch instance', () => {
+      expect(defaultUI.getModeSwitch() instanceof ModeSwitch).toBe(true);
+    });
+  });
+
+  describe('setToolbar', () => {
     it('should set new Toolbar instance and free previous instance', () => {
       const newToolbar = new Toolbar(editor.eventManager);
       const prevToolbar = defaultUI.getToolbar();
@@ -45,7 +52,7 @@ describe('DeafultUI', () => {
     });
   });
 
-  describe('_initToolbar()', () => {
+  describe('_initToolbar', () => {
     it('should populate default buttons', () => {
       expect(defaultUI.getToolbar().getItems().length).toBeGreaterThan(0);
     });

--- a/test/ui/modeSwitch.spec.js
+++ b/test/ui/modeSwitch.spec.js
@@ -7,21 +7,27 @@ import $ from 'jquery';
 import ModeSwitch from '../../src/js/ui/modeSwitch';
 
 describe('ModeSwitch', () => {
+  let $container, modeSwitch;
+
+  beforeEach(() => {
+    $container = $('<div>');
+    $('body').append($container);
+  });
+
   afterEach(() => {
-    $('body').empty();
+    modeSwitch.destroy();
+    $container.empty();
   });
 
   it('editorTypeControl should be exist', () => {
-    const modeSwitch = new ModeSwitch();
-    $('body').append(modeSwitch.$el);
+    modeSwitch = new ModeSwitch($container);
 
     expect($('.te-mode-switch').length).toEqual(1);
   });
 
   describe('should apply button type on option', () => {
     it('markdown', () => {
-      const modeSwitch = new ModeSwitch(ModeSwitch.TYPE.MARKDOWN);
-      $('body').append(modeSwitch.$el);
+      modeSwitch = new ModeSwitch($container, ModeSwitch.TYPE.MARKDOWN);
 
       expect($('button.te-switch-button.active').length).toEqual(1);
       expect($('button.te-switch-button.wysiwyg.active').length).toEqual(0);
@@ -29,8 +35,7 @@ describe('ModeSwitch', () => {
       expect($('button.te-switch-button.markdown.active').text()).toEqual('Markdown');
     });
     it('wysiwyg', () => {
-      const modeSwitch = new ModeSwitch(ModeSwitch.TYPE.WYSIWYG);
-      $('body').append(modeSwitch.$el);
+      modeSwitch = new ModeSwitch($container, ModeSwitch.TYPE.WYSIWYG);
 
       expect($('button.te-switch-button.active').length).toEqual(1);
       expect($('button.te-switch-button.markdown.active').length).toEqual(0);
@@ -40,9 +45,7 @@ describe('ModeSwitch', () => {
   });
 
   it('should add `active` class on click button', () => {
-    const modeSwitch = new ModeSwitch();
-
-    $('body').append(modeSwitch.$el);
+    modeSwitch = new ModeSwitch($container);
 
     expect($('button.te-switch-button.wysiwyg').text()).toEqual('WYSIWYG');
     expect($('button.te-switch-button.markdown.active').text()).toEqual('Markdown');
@@ -51,5 +54,27 @@ describe('ModeSwitch', () => {
 
     expect($('button.te-switch-button.wysiwyg.active').text()).toEqual('WYSIWYG');
     expect($('button.te-switch-button.markdown').text()).toEqual('Markdown');
+  });
+
+  describe('isShowing', () => {
+    it('should return is visible status', () => {
+      modeSwitch = new ModeSwitch($container);
+      expect(modeSwitch.isShowing()).toBe(true);
+
+      modeSwitch._$rootElement.css('display', 'none');
+      expect(modeSwitch.isShowing()).toBe(false);
+    });
+  });
+
+  describe('show/hide', () => {
+    it('should show/hide the base element', () => {
+      modeSwitch = new ModeSwitch($container);
+
+      modeSwitch.hide();
+      expect(modeSwitch._$rootElement.css('display')).toBe('none');
+
+      modeSwitch.show();
+      expect(modeSwitch._$rootElement.css('display')).toBe('block');
+    });
   });
 });

--- a/test/ui/modeSwitch.spec.js
+++ b/test/ui/modeSwitch.spec.js
@@ -56,13 +56,13 @@ describe('ModeSwitch', () => {
     expect($('button.te-switch-button.markdown').text()).toEqual('Markdown');
   });
 
-  describe('isShowing', () => {
+  describe('isShown', () => {
     it('should return is visible status', () => {
       modeSwitch = new ModeSwitch($container);
-      expect(modeSwitch.isShowing()).toBe(true);
+      expect(modeSwitch.isShown()).toBe(true);
 
       modeSwitch._$rootElement.css('display', 'none');
-      expect(modeSwitch.isShowing()).toBe(false);
+      expect(modeSwitch.isShown()).toBe(false);
     });
   });
 


### PR DESCRIPTION
- 옵션으로 에디터 하단 markdown/wysiwyg 탭 안보이게 감춤
- show/hide api 제공

```js
editor.getUI().getModeSwitch().hide();
```

![image](https://user-images.githubusercontent.com/1215767/38287882-34c54eec-3808-11e8-8deb-5fe2629f9f70.png)

hide ->

![image](https://user-images.githubusercontent.com/1215767/38287911-5885c99c-3808-11e8-946c-674956d4d133.png)
