### PR TITLE
docs: getting stared broken toMark-module link fixed (close)

### DIFF
--- a/docs/getting-started-with-bower.md
+++ b/docs/getting-started-with-bower.md
@@ -14,7 +14,7 @@ So these dependencies are included beforehand.
 ...
 <script src="../bower_components/jquery/dist/jquery.js"></script>
 <script src='../bower_components/markdown-it/dist/markdown-it.js'></script>
-<script src="../bower_components/toMark/dist/toMark.js"></script>
+<script src="../bower_components/to-mark/dist/to-mark.js"></script>
 <script src="../bower_components/tui-code-snippet/dist/tui-code-snippet.js"></script>
 <script src="../bower_components/codemirror/lib/codemirror.js"></script>
 <script src="../bower_components/highlightjs/highlight.pack.js"></script>


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description

toMark has become to-mark for dep. module

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
