### PR TITLE
feat: add indent/outdent toolbar buttons (close #133)

### DIFF
--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -37,6 +37,8 @@ import mdAddLink from './markdownCommands/addLink';
 import mdAddImage from './markdownCommands/addImage';
 import mdUL from './markdownCommands/ul';
 import mdOL from './markdownCommands/ol';
+import mdIndent from './markdownCommands/indent';
+import mdOutdent from './markdownCommands/outdent';
 import mdTable from './markdownCommands/table';
 import mdTask from './markdownCommands/task';
 import mdCode from './markdownCommands/code';
@@ -61,8 +63,8 @@ import wwTableRemoveRow from './wysiwygCommands/tableRemoveRow';
 import wwTableRemoveCol from './wysiwygCommands/tableRemoveCol';
 import wwTableAlignCol from './wysiwygCommands/tableAlignCol';
 import wwTableRemove from './wysiwygCommands/tableRemove';
-import wwIncreaseDepth from './wysiwygCommands/increaseDepth';
-import wwDecreaseDepth from './wysiwygCommands/decreaseDepth';
+import wwIndent from './wysiwygCommands/indent';
+import wwOutdent from './wysiwygCommands/outdent';
 import wwTask from './wysiwygCommands/task';
 import wwCode from './wysiwygCommands/code';
 import wwCodeBlock from './wysiwygCommands/codeBlock';
@@ -138,9 +140,12 @@ class ToastUIEditor {
         'divider',
         'hr',
         'quote',
+        'divider',
         'ul',
         'ol',
         'task',
+        'indent',
+        'outdent',
         'divider',
         'table',
         'image',
@@ -247,6 +252,8 @@ class ToastUIEditor {
     this.addCommand(mdAddImage);
     this.addCommand(mdUL);
     this.addCommand(mdOL);
+    this.addCommand(mdIndent);
+    this.addCommand(mdOutdent);
     this.addCommand(mdTable);
     this.addCommand(mdTask);
     this.addCommand(mdCode);
@@ -263,8 +270,8 @@ class ToastUIEditor {
     this.addCommand(wwHR);
     this.addCommand(wwHeading);
     this.addCommand(wwParagraph);
-    this.addCommand(wwIncreaseDepth);
-    this.addCommand(wwDecreaseDepth);
+    this.addCommand(wwIndent);
+    this.addCommand(wwOutdent);
     this.addCommand(wwTask);
     this.addCommand(wwTable);
     this.addCommand(wwTableAddRow);

--- a/src/js/langs/de_DE.js
+++ b/src/js/langs/de_DE.js
@@ -20,6 +20,8 @@ i18n.setLanguage(['de', 'de_DE'], {
   'Unordered list': 'Aufzählung',
   'Ordered list': 'Nummerierte Aufzählung',
   'Task': 'Aufgabe',
+  'Indent': 'inspringen',
+  'Outdent': 'Uithangen',
   'Insert link': 'Link einfügen',
   'Insert CodeBlock': 'Codeblock einfügen',
   'Insert table': 'Tabelle einfügen',

--- a/src/js/langs/en_US.js
+++ b/src/js/langs/en_US.js
@@ -20,6 +20,8 @@ i18n.setLanguage(['en', 'en_US'], {
   'Unordered list': 'Unordered list',
   'Ordered list': 'Ordered list',
   'Task': 'Task',
+  'Indent': 'Indent',
+  'Outdent': 'Outdent',
   'Insert link': 'Insert link',
   'Insert CodeBlock': 'Insert codeBlock',
   'Insert table': 'Insert table',

--- a/src/js/langs/es_ES.js
+++ b/src/js/langs/es_ES.js
@@ -20,6 +20,8 @@ i18n.setLanguage(['es', 'es_ES'], {
   'Unordered list': 'Lista desordenada',
   'Ordered list': 'Lista ordenada',
   'Task': 'Tarea',
+  'Indent': 'Sangría',
+  'Outdent': 'Saliendo',
   'Insert link': 'Insertar enlace',
   'Insert CodeBlock': 'Insertar bloque de código',
   'Insert table': 'Insertar tabla',

--- a/src/js/langs/fr_FR.js
+++ b/src/js/langs/fr_FR.js
@@ -20,6 +20,8 @@ i18n.setLanguage(['fr', 'fr_FR'], {
   'Unordered list': 'Liste non-ordonnée',
   'Ordered list': 'Liste ordonnée',
   'Task': 'Tâche',
+  'Indent': 'Retrait',
+  'Outdent': 'Sortir',
   'Insert link': 'Insérer un lien',
   'Insert CodeBlock': 'Insérer un bloc de code',
   'Insert table': 'Insérer un tableau',

--- a/src/js/langs/ja_JP.js
+++ b/src/js/langs/ja_JP.js
@@ -20,6 +20,8 @@ i18n.setLanguage(['ja', 'ja_JP'], {
   'Unordered list': '番号なしリスト',
   'Ordered list': '順序付きリスト',
   'Task': 'タスク',
+  'Indent': 'インデント',
+  'Outdent': 'アウトデント',
   'Insert link': 'リンク挿入',
   'Insert CodeBlock': 'コードブロック挿入',
   'Insert table': 'テーブル挿入',

--- a/src/js/langs/ko_KR.js
+++ b/src/js/langs/ko_KR.js
@@ -20,6 +20,8 @@ i18n.setLanguage(['ko', 'ko_KR'], {
   'Unordered list': '글머리 기호',
   'Ordered list': '번호 매기기',
   'Task': '체크박스',
+  'Indent': '들여쓰기',
+  'Outdent': '내어쓰기',
   'Insert link': '링크 삽입',
   'Insert CodeBlock': '코드블럭 삽입',
   'Insert table': '표 삽입',

--- a/src/js/langs/nl_NL.js
+++ b/src/js/langs/nl_NL.js
@@ -20,6 +20,8 @@ i18n.setLanguage(['nl', 'nl_NL'], {
   'Unordered list': 'Opsomming',
   'Ordered list': 'Genummerde opsomming',
   'Task': 'Taak',
+  'Indent': 'Inspringen',
+  'Outdent': 'Outdent',
   'Insert link': 'Link invoegen',
   'Insert CodeBlock': 'Codeblok toevoegen',
   'Insert table': 'Tabel invoegen',

--- a/src/js/langs/ru_RU.js
+++ b/src/js/langs/ru_RU.js
@@ -20,6 +20,8 @@ i18n.setLanguage(['ru', 'ru_RU'], {
   'Unordered list': 'Неупорядоченный список',
   'Ordered list': 'Упорядоченный список',
   'Task': 'Задача',
+  'Indent': 'отступ',
+  'Outdent': 'Выступ',
   'Insert link': 'Вставить ссылку',
   'Insert CodeBlock': 'Вставить код',
   'Insert table': 'Вставить таблицу',

--- a/src/js/langs/uk_UA.js
+++ b/src/js/langs/uk_UA.js
@@ -20,6 +20,8 @@ i18n.setLanguage(['uk', 'uk_UA'], {
   'Unordered list': 'Невпорядкований список',
   'Ordered list': 'Упорядкований список',
   'Task': 'Завдання',
+  'Indent': 'відступ',
+  'Outdent': 'застарілий',
   'Insert link': 'Вставити посилання',
   'Insert CodeBlock': 'Вставити код',
   'Insert table': 'Вставити таблицю',

--- a/src/js/langs/zh_CN.js
+++ b/src/js/langs/zh_CN.js
@@ -20,6 +20,8 @@ i18n.setLanguage(['zh', 'zh_CN'], {
   'Unordered list': '无序列表',
   'Ordered list': '有序列表',
   'Task': '任务',
+  'Indent': '缩进',
+  'Outdent': '减少缩进',
   'Insert link': '插入链接',
   'Insert CodeBlock': '插入代码块',
   'Insert table': '插入表格',

--- a/src/js/markdownCommands/indent.js
+++ b/src/js/markdownCommands/indent.js
@@ -1,0 +1,27 @@
+/**
+ * @fileoverview Implements Indent markdown command
+ * @author NHN Ent. FE Development Lab <dl_javascript@nhnent.com>
+ */
+
+import CommandManager from '../commandManager';
+
+/**
+ * Indent
+ * Add Indent markdown syntax to markdown editor
+ * @extends Command
+ * @module markdownCommands/inent
+ * @ignore
+ */
+const Indent = CommandManager.command('markdown', /** @lends Indent */{
+  name: 'Indent',
+  /**
+   * Command handler
+   * @param {MarkdownEditor} mde MarkdownEditor instance
+   */
+  exec(mde) {
+    const cm = mde.getEditor();
+    cm.execCommand('subListIndentTab');
+  }
+});
+
+export default Indent;

--- a/src/js/markdownCommands/outdent.js
+++ b/src/js/markdownCommands/outdent.js
@@ -1,0 +1,27 @@
+/**
+ * @fileoverview Implements Outdent markdown command
+ * @author NHN Ent. FE Development Lab <dl_javascript@nhnent.com>
+ */
+
+import CommandManager from '../commandManager';
+
+/**
+ * Outdent
+ * Add Outdent markdown syntax to markdown editor
+ * @extends Command
+ * @module markdownCommands/outdent
+ * @ignore
+ */
+const Outdent = CommandManager.command('markdown', /** @lends Outdent */{
+  name: 'Outdent',
+  /**
+   * Command handler
+   * @param {MarkdownEditor} mde MarkdownEditor instance
+   */
+  exec(mde) {
+    const cm = mde.getEditor();
+    cm.execCommand('indentLessOrderedList');
+  }
+});
+
+export default Outdent;

--- a/src/js/ui/toolbarItemFactory.js
+++ b/src/js/ui/toolbarItemFactory.js
@@ -144,6 +144,22 @@ class ToolbarItemFactory {
         state: 'codeBlock'
       });
       break;
+    case 'indent':
+      toolbarItem = new ToolbarButton({
+        name: 'indent',
+        className: 'tui-indent',
+        command: 'Indent',
+        tooltip: i18n.get('Indent')
+      });
+      break;
+    case 'outdent':
+      toolbarItem = new ToolbarButton({
+        name: 'outdent',
+        className: 'tui-outdent',
+        command: 'Outdent',
+        tooltip: i18n.get('Outdent')
+      });
+      break;
     case 'divider':
       toolbarItem = new ToolbarDivider();
       break;

--- a/src/js/wwListManager.js
+++ b/src/js/wwListManager.js
@@ -80,7 +80,7 @@ class WwListManager {
       if (range.collapsed) {
         if (this.wwe.getEditor().hasFormat('LI')) {
           ev.preventDefault();
-          this.eventManager.emit('command', 'IncreaseDepth');
+          this.eventManager.emit('command', 'Indent');
 
           isNeedNext = false;
         }
@@ -97,7 +97,7 @@ class WwListManager {
           ev.preventDefault();
           const $ul = $(range.startContainer).closest('li').children(UL_OR_OL);
 
-          this.eventManager.emit('command', 'DecreaseDepth');
+          this.eventManager.emit('command', 'Outdent');
 
           if ($ul.length && !$ul.prev().length) {
             this._removeBranchList($ul);

--- a/src/js/wysiwygCommands/indent.js
+++ b/src/js/wysiwygCommands/indent.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Implements incease depth wysiwyg command
+ * @fileoverview Implements Indent wysiwyg command
  * @author NHN Ent. FE Development Lab <dl_javascript@nhnent.com>
  */
 import $ from 'jquery';
@@ -7,14 +7,14 @@ import $ from 'jquery';
 import CommandManager from '../commandManager';
 
 /**
- * IncreaseDepth
- * increase depth of list or task to wysiwyg Editor
+ * Indent
+ * Indent list or task to wysiwyg Editor
  * @extends Command
- * @module wysiwygCommands/IncreaseDepth
+ * @module wysiwygCommands/indent
  * @ignore
  */
-const IncreaseDepth = CommandManager.command('wysiwyg', /** @lends HR */{
-  name: 'IncreaseDepth',
+const Indent = CommandManager.command('wysiwyg', /** @lends Indent */{
+  name: 'Indent',
   /**
    * Command Handler
    * @param {WysiwygEditor} wwe wysiwygEditor instance
@@ -53,4 +53,4 @@ const IncreaseDepth = CommandManager.command('wysiwyg', /** @lends HR */{
   }
 });
 
-export default IncreaseDepth;
+export default Indent;

--- a/src/js/wysiwygCommands/outdent.js
+++ b/src/js/wysiwygCommands/outdent.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Implements decrease depth wysiwyg command
+ * @fileoverview Implements Outdent wysiwyg command
  * @author NHN Ent. FE Development Lab <dl_javascript@nhnent.com>
  */
 import $ from 'jquery';
@@ -7,14 +7,14 @@ import $ from 'jquery';
 import CommandManager from '../commandManager';
 
 /**
- * DecreaseDepth
- * decrease depth of list or task to wysiwyg Editor
+ * Outdent
+ * Outdent list or task to wysiwyg Editor
  * @extends Command
- * @module wysiwygCommands/DecreaseDepth
+ * @module wysiwygCommands/Outdent
  * @ignore
  */
-const DecreaseDepth = CommandManager.command('wysiwyg', /** @lends HR */{
-  name: 'DecreaseDepth',
+const Outdent = CommandManager.command('wysiwyg', /** @lends Outdent */{
+  name: 'Outdent',
 
   /**
    * Command Handler
@@ -36,7 +36,7 @@ const DecreaseDepth = CommandManager.command('wysiwyg', /** @lends HR */{
 });
 
 /**
- * test if decrease the depth of given list item
+ * test if outdent the given list item
  * arbitrary list allows list item to be in any position
  * while markdown spec does not
  * @param {jQuery} $currentLiNode - jQuery list item element
@@ -59,4 +59,4 @@ function getCurrent$Li(wwe) {
   return $(range.startContainer).closest('li');
 }
 
-export default DecreaseDepth;
+export default Outdent;

--- a/test/editor.spec.js
+++ b/test/editor.spec.js
@@ -327,16 +327,19 @@ describe('Editor', () => {
         expect(toolbarItems[4].getName()).toBe('divider');
         expect(toolbarItems[5].getName()).toBe('hr');
         expect(toolbarItems[6].getName()).toBe('quote');
-        expect(toolbarItems[7].getName()).toBe('ul');
-        expect(toolbarItems[8].getName()).toBe('ol');
-        expect(toolbarItems[9].getName()).toBe('task');
-        expect(toolbarItems[10].getName()).toBe('divider');
-        expect(toolbarItems[11].getName()).toBe('table');
-        expect(toolbarItems[12].getName()).toBe('image');
-        expect(toolbarItems[13].getName()).toBe('link');
-        expect(toolbarItems[14].getName()).toBe('divider');
-        expect(toolbarItems[15].getName()).toBe('code');
-        expect(toolbarItems[16].getName()).toBe('codeblock');
+        expect(toolbarItems[7].getName()).toBe('divider');
+        expect(toolbarItems[8].getName()).toBe('ul');
+        expect(toolbarItems[9].getName()).toBe('ol');
+        expect(toolbarItems[10].getName()).toBe('task');
+        expect(toolbarItems[11].getName()).toBe('indent');
+        expect(toolbarItems[12].getName()).toBe('outdent');
+        expect(toolbarItems[13].getName()).toBe('divider');
+        expect(toolbarItems[14].getName()).toBe('table');
+        expect(toolbarItems[15].getName()).toBe('image');
+        expect(toolbarItems[16].getName()).toBe('link');
+        expect(toolbarItems[17].getName()).toBe('divider');
+        expect(toolbarItems[18].getName()).toBe('code');
+        expect(toolbarItems[19].getName()).toBe('codeblock');
       });
 
       it('should populate custom toolbar buttons according to given array', () => {

--- a/test/markdownCommands/indent.spec.js
+++ b/test/markdownCommands/indent.spec.js
@@ -1,0 +1,41 @@
+/**
+ * @fileoverview test markdown hr
+ * @author NHN Ent. FE Development Lab <dl_javascript@nhnent.com>
+ */
+import $ from 'jquery';
+
+import Indent from '../../src/js/markdownCommands/indent';
+import MarkdownEditor from '../../src/js/markdownEditor';
+import EventManager from '../../src/js/eventManager';
+
+describe('Indent', () => {
+  let cm, mde, $container;
+
+  beforeEach(() => {
+    $container = $('<div />');
+
+    $('body').append($container);
+
+    mde = new MarkdownEditor($container, new EventManager());
+
+    cm = mde.getEditor();
+
+    const sourceText = ['* list1', '* list2', '* list3'];
+
+    cm.setValue(sourceText.join('\n'));
+  });
+
+  afterEach(() => {
+    $container.remove();
+  });
+
+  describe('Indent', () => {
+    it('should indent current line', () => {
+      cm.setCursor(1, 3);
+
+      Indent.exec(mde);
+
+      expect(cm.getValue()).toEqual(['* list1', '    * list2', '* list3'].join('\n'));
+    });
+  });
+});

--- a/test/markdownCommands/outdent.spec.js
+++ b/test/markdownCommands/outdent.spec.js
@@ -1,0 +1,41 @@
+/**
+ * @fileoverview test markdown Outdent
+ * @author NHN Ent. FE Development Lab <dl_javascript@nhnent.com>
+ */
+import $ from 'jquery';
+
+import Outdent from '../../src/js/markdownCommands/outdent';
+import MarkdownEditor from '../../src/js/markdownEditor';
+import EventManager from '../../src/js/eventManager';
+
+describe('Outdent', () => {
+  let cm, mde, $container;
+
+  beforeEach(() => {
+    $container = $('<div />');
+
+    $('body').append($container);
+
+    mde = new MarkdownEditor($container, new EventManager());
+
+    cm = mde.getEditor();
+
+    const sourceText = ['    * list1', '    * list2', '    * list3'];
+
+    cm.setValue(sourceText.join('\n'));
+  });
+
+  afterEach(() => {
+    $container.remove();
+  });
+
+  describe('Outdent', () => {
+    it('should indent current line', () => {
+      cm.setCursor(1, 3);
+
+      Outdent.exec(mde);
+
+      expect(cm.getValue()).toEqual(['    * list1', '* list2', '    * list3'].join('\n'));
+    });
+  });
+});

--- a/test/ui/toolbarItemFactory.spec.js
+++ b/test/ui/toolbarItemFactory.spec.js
@@ -55,6 +55,8 @@ describe('ToolbarItemFactory', () => {
       expect(ToolbarItemFactory.create('link').getName()).toBe('link');
       expect(ToolbarItemFactory.create('code').getName()).toBe('code');
       expect(ToolbarItemFactory.create('codeblock').getName()).toBe('codeblock');
+      expect(ToolbarItemFactory.create('indent').getName()).toBe('indent');
+      expect(ToolbarItemFactory.create('outdent').getName()).toBe('outdent');
       expect(ToolbarItemFactory.create('item').getName()).toBe('item');
     });
   });

--- a/test/wysiwygCommands/indent.spec.js
+++ b/test/wysiwygCommands/indent.spec.js
@@ -1,16 +1,16 @@
 /**
- * @fileoverview test wysiwyg increase depth command
+ * @fileoverview test wysiwyg indent command
  * @author NHN Ent. FE Development Lab <dl_javascript@nhnent.com>
  */
 import $ from 'jquery';
 
-import IncreaseDepth from '../../src/js/wysiwygCommands/increaseDepth';
+import Indent from '../../src/js/wysiwygCommands/indent';
 import WwTaskManager from '../../src/js/wwTaskManager';
 import WwListManager from '../../src/js/wwListManager';
 import WysiwygEditor from '../../src/js/wysiwygEditor';
 import EventManager from '../../src/js/eventManager';
 
-describe('IncreaseDepth', () => {
+describe('Indent', () => {
   let wwe, sq, container;
 
   beforeEach(() => {
@@ -51,7 +51,7 @@ describe('IncreaseDepth', () => {
 
     sq.setSelection(range);
 
-    IncreaseDepth.exec(wwe);
+    Indent.exec(wwe);
 
     expect(sq.get$Body().find('ul ul li').length).toEqual(1);
     expect(sq.get$Body().find('ul ul li').hasClass('task-list-item')).toBe(true);
@@ -64,11 +64,11 @@ describe('IncreaseDepth', () => {
 
     sq.setSelection(range);
 
-    IncreaseDepth.exec(wwe);
+    Indent.exec(wwe);
 
     expect(sq.get$Body().find('ul ul li').length).toEqual(0);
   });
-  describe('should increase depth when cursor', () => {
+  describe('should indent when cursor', () => {
     it('at startOffset 0.', () => {
       const range = wwe.getEditor().getSelection().cloneRange();
 
@@ -77,7 +77,7 @@ describe('IncreaseDepth', () => {
 
       sq.setSelection(range);
 
-      IncreaseDepth.exec(wwe);
+      Indent.exec(wwe);
 
       expect(sq.get$Body().find('ul ul li').length).toEqual(1);
       expect(sq.get$Body().find('ul ul li').hasClass('task-list-item')).toBe(true);
@@ -90,13 +90,13 @@ describe('IncreaseDepth', () => {
 
       sq.setSelection(range);
 
-      IncreaseDepth.exec(wwe);
+      Indent.exec(wwe);
 
       expect(sq.get$Body().find('ul ul li').length).toEqual(1);
       expect(sq.get$Body().find('ul ul li').hasClass('task-list-item')).toBe(true);
     });
   });
-  it('should increase ordinary list', () => {
+  it('should indent ordinary list', () => {
     const range = wwe.getEditor().getSelection().cloneRange();
 
     wwe.get$Body().html(`
@@ -117,7 +117,7 @@ describe('IncreaseDepth', () => {
 
     sq.setSelection(range);
 
-    IncreaseDepth.exec(wwe);
+    Indent.exec(wwe);
 
     expect(sq.get$Body().find('ul > li').length).toEqual(4);
     expect(sq.get$Body().find('ul > ul > li').length).toEqual(3);
@@ -125,7 +125,7 @@ describe('IncreaseDepth', () => {
     expect(sq.get$Body().find('ul > ul > ul > li').hasClass('task-list-item')).toBe(true);
   });
 
-  it('should merge prev/next list after increase depth', () => {
+  it('should merge prev/next list after outdent', () => {
     const range = wwe.getEditor().getSelection().cloneRange();
 
     wwe.get$Body().html(`
@@ -148,7 +148,7 @@ describe('IncreaseDepth', () => {
 
     sq.setSelection(range);
 
-    IncreaseDepth.exec(wwe);
+    Indent.exec(wwe);
 
     expect(sq.get$Body().find('> ul > li').length).toEqual(1);
     expect(sq.get$Body().find('> ul > ol > li').length).toEqual(5);

--- a/test/wysiwygCommands/outdent.spec.js
+++ b/test/wysiwygCommands/outdent.spec.js
@@ -1,15 +1,15 @@
 /**
- * @fileoverview test wysiwyg decrease depth command
+ * @fileoverview test wysiwyg outdent command
  * @author NHN Ent. FE Development Lab <dl_javascript@nhnent.com>
  */
 import $ from 'jquery';
 
-import DecreaseDepth from '../../src/js/wysiwygCommands/decreaseDepth';
+import Outdent from '../../src/js/wysiwygCommands/outdent';
 import WwTaskManager from '../../src/js/wwTaskManager';
 import WysiwygEditor from '../../src/js/wysiwygEditor';
 import EventManager from '../../src/js/eventManager';
 
-describe('DecreaseDepth', () => {
+describe('Outdent', () => {
   let wwe, sq, container;
 
   beforeEach(() => {
@@ -42,7 +42,7 @@ describe('DecreaseDepth', () => {
     });
   });
 
-  it('should be able to decrease depth second to first.', () => {
+  it('should be able to outdent second to first.', () => {
     const range = wwe.getEditor().getSelection().cloneRange();
 
     range.setStart(wwe.get$Body().find('li')[1].firstChild, 0);
@@ -50,7 +50,7 @@ describe('DecreaseDepth', () => {
 
     sq.setSelection(range);
 
-    DecreaseDepth.exec(wwe);
+    Outdent.exec(wwe);
 
     expect(sq.get$Body().find('ul > li').length).toEqual(3);
     expect(sq.get$Body().find('ul > ul > li').length).toEqual(0);
@@ -65,7 +65,7 @@ describe('DecreaseDepth', () => {
 
     sq.setSelection(range);
 
-    DecreaseDepth.exec(wwe);
+    Outdent.exec(wwe);
 
     expect(sq.get$Body().find('ul li').length).toEqual(2);
     expect(sq.get$Body().find('ul ul li').length).toEqual(1);
@@ -89,7 +89,7 @@ describe('DecreaseDepth', () => {
 
     sq.setSelection(range);
 
-    DecreaseDepth.exec(wwe);
+    Outdent.exec(wwe);
 
     const $Body = sq.get$Body();
 
@@ -100,7 +100,7 @@ describe('DecreaseDepth', () => {
     expect($Body.find('ul li').eq(2).hasClass('task-list-item')).toBe(true);
   });
 
-  it('should not decrease if next element is UL/OL (arbitrary list)', () => {
+  it('should not outdent if next element is UL/OL (arbitrary list)', () => {
     const range = wwe.getEditor().getSelection().cloneRange();
 
     wwe.get$Body().html(`
@@ -120,7 +120,7 @@ describe('DecreaseDepth', () => {
 
     sq.setSelection(range);
 
-    DecreaseDepth.exec(wwe);
+    Outdent.exec(wwe);
 
     const $Body = sq.get$Body();
 
@@ -129,7 +129,7 @@ describe('DecreaseDepth', () => {
     expect($Body.find('> ul > ul > ul > li').length).toEqual(1);
   });
 
-  describe('should decrease depth when cursor', () => {
+  describe('should outdent when cursor', () => {
     it('at startOffset 0.', () => {
       const range = wwe.getEditor().getSelection().cloneRange();
 
@@ -138,13 +138,13 @@ describe('DecreaseDepth', () => {
 
       sq.setSelection(range);
 
-      DecreaseDepth.exec(wwe);
+      Outdent.exec(wwe);
 
       expect(sq.get$Body().find('ul > li').length).toEqual(3);
       expect(sq.get$Body().find('ul ul li').length).toEqual(0);
       expect(sq.get$Body().find('ul > li').hasClass('task-list-item')).toBe(true);
     });
-    it('should decrease depth when cursor at any offset.', () => {
+    it('at any offset.', () => {
       const range = wwe.getEditor().getSelection().cloneRange();
 
       range.setStart(wwe.get$Body().find('li')[1].firstChild, 2);
@@ -152,7 +152,7 @@ describe('DecreaseDepth', () => {
 
       sq.setSelection(range);
 
-      DecreaseDepth.exec(wwe);
+      Outdent.exec(wwe);
 
       expect(sq.get$Body().find('ul > li').length).toEqual(3);
       expect(sq.get$Body().find('ul ul li').length).toEqual(0);


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1215767/38296066-2cd9915c-382b-11e8-8bb8-d9b34c3c299b.png)

* 기존 tab, shift-tab과 동일한 동작 수행
  * 리스트 인덴트과 관련된 버그들은 별도 작업
* IncreaseDepth/DecreaseDepth 이름 Indent/Outdent로 통일
* 버튼 이미지는 이어지는 이미지 교체 작업에서 수행
