### PR TITLE
docs: improve english expression (fix #131)

### DIFF
--- a/docs/ISSUE_TEMPLATE.md
+++ b/docs/ISSUE_TEMPLATE.md
@@ -1,8 +1,9 @@
 <!--
 Thank you for your contribution.
 
-When it comes to write an issue, please, use the template below.
-To use the template is mandatory for submit new issue and we won't reply the issue that without the template.
+When writing an issue, please, use the template below.
+It's mandatory to use the template for submitting the new issue.
+We dont't reply to the issue not following the template.
 -->
 
 <!-- BUG ISSUE TEMPLATE -->
@@ -13,11 +14,12 @@ To use the template is mandatory for submit new issue and we won't reply the iss
 <!-- Write the browser type, OS and so on -->
 
 ## Current Behavior
-<!-- Write a description of the detailed step to reproduce the current behavior. You can add sample code, 'CodePen' or 'jsfiddle' links. -->
+<!-- Write steps to reproduce the current behavior in detail.
+You can add sample code, 'CodePen' or 'jsfiddle' links. -->
 
 ```js
 // Write example code
 ```
 
 ## Expected Behavior
-<!-- Write a description of the future action. -->
+<!-- Write a description for future action. -->


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### By the way..
In my opinion, it would be more consistent if the title of PR uses `(fixes #xxx)` rather than `(fix #xxx)`. For instance, [eslint](https://github.com/eslint/eslint/pulls?q=is%3Aopen+is%3Apr) uses `(fixes #xxx)` both on commit message and PR title. Of course, it fully depends on cultures and is quite hard to change in mature, traditional convention. But as __tui.editor__ is pretty new, it might be adequate time to update the policy.