### PR TITLE
feat: add plantuml language for uml plugin (close #87)

### DIFF
--- a/src/js/extensions/uml.js
+++ b/src/js/extensions/uml.js
@@ -8,7 +8,7 @@ import Editor from './editorProxy';
 
 const {codeBlockManager} = Editor;
 const DEFAULT_RENDERER_URL = 'http://www.plantuml.com/plantuml/png/';
-const LANG = 'uml';
+const UML_LANGUAGES = ['uml', 'plantuml'];
 
 /**
  * plant uml plugin
@@ -42,11 +42,13 @@ function umlExtension(editor, options = {}) {
     return renderedHTML;
   }
 
-  const optionLanguages = editor.options.codeBlockLanguages;
-  if (optionLanguages && optionLanguages.indexOf(LANG) < 0) {
-    optionLanguages.push(LANG);
-  }
-  codeBlockManager.setReplacer(LANG, plantUMLReplacer);
+  const {codeBlockLanguages} = editor.options;
+  UML_LANGUAGES.forEach(umlLanguage => {
+    if (codeBlockLanguages.indexOf(umlLanguage) < 0) {
+      codeBlockLanguages.push(umlLanguage);
+    }
+    codeBlockManager.setReplacer(umlLanguage, plantUMLReplacer);
+  });
 }
 
 Editor.defineExtension('uml', umlExtension);

--- a/test/extensions/uml.spec.js
+++ b/test/extensions/uml.spec.js
@@ -25,6 +25,7 @@ describe('uml extension', () => {
   });
 
   it('create plant uml image in markdown preview', () => {
+    const lang = 'uml';
     editor = new TuiEditor({
       el: wrapper,
       previewStyle: 'vertical',
@@ -33,7 +34,7 @@ describe('uml extension', () => {
       exts: ['uml']
     });
 
-    editor.setValue(`\`\`\`uml\nAlice -> Bob: Hello\n\`\`\``);
+    editor.setValue(`\`\`\`${lang}\nAlice -> Bob: Hello\n\`\`\``);
 
     jasmine.clock().tick(800);
 
@@ -41,6 +42,7 @@ describe('uml extension', () => {
   });
 
   it('create plant uml image for code block language plantuml', () => {
+    const lang = 'plantuml';
     editor = new TuiEditor({
       el: wrapper,
       previewStyle: 'vertical',
@@ -49,7 +51,7 @@ describe('uml extension', () => {
       exts: ['uml']
     });
 
-    editor.setValue(`\`\`\`plantuml\nAlice -> Bob: Hello\n\`\`\``);
+    editor.setValue(`\`\`\`${lang}\nAlice -> Bob: Hello\n\`\`\``);
 
     jasmine.clock().tick(800);
 

--- a/test/extensions/uml.spec.js
+++ b/test/extensions/uml.spec.js
@@ -40,6 +40,22 @@ describe('uml extension', () => {
     expect(editor.preview.$el.get(0).querySelector('pre img').getAttribute('src')).toEqual('http://www.plantuml.com/plantuml/png/Syp9J4vLqBLJSCfFibBmICt9oUS20000');
   });
 
+  it('create plant uml image for code block language plantuml', () => {
+    editor = new TuiEditor({
+      el: wrapper,
+      previewStyle: 'vertical',
+      height: '100px',
+      initialEditType: 'markdown',
+      exts: ['uml']
+    });
+
+    editor.setValue(`\`\`\`plantuml\nAlice -> Bob: Hello\n\`\`\``);
+
+    jasmine.clock().tick(800);
+
+    expect(editor.preview.$el.get(0).querySelector('pre img').getAttribute('src')).toEqual('http://www.plantuml.com/plantuml/png/Syp9J4vLqBLJSCfFibBmICt9oUS20000');
+  });
+
   it('shows code in html in wysiwyg', () => {
     editor = new TuiEditor({
       el: wrapper,


### PR DESCRIPTION
add `plantuml` language as a uml plugin language to be rendered.
It was the only language `uml` to be rendered.