### PR TITLE
fix: Make popups absolutely positioned in toolbar (fix #151, #155)

### DIFF
--- a/src/js/ui/defaultUI.js
+++ b/src/js/ui/defaultUI.js
@@ -232,7 +232,7 @@ class DefaultUI {
       eventManager: this._editor.eventManager,
       $button: this.$el.find('button.tui-table'),
       css: {
-        'position': 'fixed'
+        'position': 'absolute'
       }
     }));
   }
@@ -243,7 +243,7 @@ class DefaultUI {
       eventManager: this._editor.eventManager,
       $button: this.$el.find('button.tui-heading'),
       css: {
-        'position': 'fixed'
+        'position': 'absolute'
       }
     }));
   }

--- a/src/js/ui/popupAddHeading.js
+++ b/src/js/ui/popupAddHeading.js
@@ -82,7 +82,10 @@ class PopupAddHeading extends LayerPopup {
     this._eventManager.listen('closeAllPopup', this.hide.bind(this));
     this._eventManager.listen('openHeadingSelect', () => {
       const $button = this._$button;
-      const offset = $button.offset();
+      const offset = {
+        top: $button[0].offsetTop,
+        left: $button[0].offsetLeft,
+      };
 
       this.$el.css({
         top: offset.top + $button.outerHeight(),

--- a/src/js/ui/popupAddTable.js
+++ b/src/js/ui/popupAddTable.js
@@ -141,7 +141,11 @@ class PopupAddTable extends LayerPopup {
 
     this._eventManager.listen('openPopupAddTable', () => {
       const $button = this._$button;
-      const offset = $button.offset();
+      const offset = {
+        top: $button[0].offsetTop,
+        left: $button[0].offsetLeft,
+      };
+
       this.$el.css({
         top: offset.top + $button.outerHeight(),
         left: offset.left


### PR DESCRIPTION
Fixes #151 and #155 

Popups will now be absolutely positioned and their offset position will be calculated relative to parent component.