### PR TITLE
fix: Make color syntax popup absolutely positioned in toolbar

### DIFF
--- a/src/js/extensions/colorSyntax.js
+++ b/src/js/extensions/colorSyntax.js
@@ -174,7 +174,7 @@ function initUI(editor, preset) {
     $target: editor.getUI().$el,
     css: {
       'width': 'auto',
-      'position': 'fixed'
+      'position': 'absolute'
     }
   });
 
@@ -189,7 +189,10 @@ function initUI(editor, preset) {
       return;
     }
 
-    const offset = $button.offset();
+    const offset = {
+      top: $button[0].offsetTop,
+      left: $button[0].offsetLeft
+    };
     popup.$el.css({
       top: offset.top + $button.outerHeight(),
       left: offset.left

--- a/src/js/ui/defaultUI.js
+++ b/src/js/ui/defaultUI.js
@@ -232,7 +232,7 @@ class DefaultUI {
       eventManager: this._editor.eventManager,
       $button: this.$el.find('button.tui-table'),
       css: {
-        'position': 'fixed'
+        'position': 'absolute'
       }
     }));
   }
@@ -243,7 +243,7 @@ class DefaultUI {
       eventManager: this._editor.eventManager,
       $button: this.$el.find('button.tui-heading'),
       css: {
-        'position': 'fixed'
+        'position': 'absolute'
       }
     }));
   }

--- a/src/js/ui/popupAddHeading.js
+++ b/src/js/ui/popupAddHeading.js
@@ -82,7 +82,10 @@ class PopupAddHeading extends LayerPopup {
     this._eventManager.listen('closeAllPopup', this.hide.bind(this));
     this._eventManager.listen('openHeadingSelect', () => {
       const $button = this._$button;
-      const offset = $button.offset();
+      const offset = {
+        top: $button[0].offsetTop,
+        left: $button[0].offsetLeft,
+      };
 
       this.$el.css({
         top: offset.top + $button.outerHeight(),

--- a/src/js/ui/popupAddTable.js
+++ b/src/js/ui/popupAddTable.js
@@ -141,7 +141,11 @@ class PopupAddTable extends LayerPopup {
 
     this._eventManager.listen('openPopupAddTable', () => {
       const $button = this._$button;
-      const offset = $button.offset();
+      const offset = {
+        top: $button[0].offsetTop,
+        left: $button[0].offsetLeft,
+      };
+
       this.$el.css({
         top: offset.top + $button.outerHeight(),
         left: offset.left


### PR DESCRIPTION
Fix color picker position on page with scrollbar.

Fix copied from : https://github.com/nhnent/tui.editor/pull/195