### PR TITLE
fix: Make popups absolutely positioned AND children of the toolbar (fix #151, #155)

### DIFF
--- a/src/js/extensions/colorSyntax.js
+++ b/src/js/extensions/colorSyntax.js
@@ -189,10 +189,13 @@ function initUI(editor, preset) {
       return;
     }
 
-    const offset = $button.offset();
+    const {
+      offsetTop,
+      offsetLeft
+    } = $button.get(0);
     popup.$el.css({
-      top: offset.top + $button.outerHeight(),
-      left: offset.left
+      top: offsetTop + $button.outerHeight(),
+      left: offsetLeft
     });
     colorPicker.slider.toggle(true);
 

--- a/src/js/ui/defaultUI.js
+++ b/src/js/ui/defaultUI.js
@@ -228,7 +228,7 @@ class DefaultUI {
 
   _initPopupAddTable() {
     this._popups.push(new PopupAddTable({
-      $target: this.$el,
+      $target: this._toolbar.$el,
       eventManager: this._editor.eventManager,
       $button: this.$el.find('button.tui-table'),
       css: {
@@ -239,7 +239,7 @@ class DefaultUI {
 
   _initPopupAddHeading() {
     this._popups.push(new PopupAddHeading({
-      $target: this.$el,
+      $target: this._toolbar.$el,
       eventManager: this._editor.eventManager,
       $button: this.$el.find('button.tui-heading'),
       css: {

--- a/src/js/ui/defaultUI.js
+++ b/src/js/ui/defaultUI.js
@@ -232,7 +232,7 @@ class DefaultUI {
       eventManager: this._editor.eventManager,
       $button: this.$el.find('button.tui-table'),
       css: {
-        'position': 'fixed'
+        'position': 'absolute'
       }
     }));
   }
@@ -243,7 +243,7 @@ class DefaultUI {
       eventManager: this._editor.eventManager,
       $button: this.$el.find('button.tui-heading'),
       css: {
-        'position': 'fixed'
+        'position': 'absolute'
       }
     }));
   }

--- a/src/js/ui/popupAddHeading.js
+++ b/src/js/ui/popupAddHeading.js
@@ -82,7 +82,10 @@ class PopupAddHeading extends LayerPopup {
     this._eventManager.listen('closeAllPopup', this.hide.bind(this));
     this._eventManager.listen('openHeadingSelect', () => {
       const $button = this._$button;
-      const offset = $button.offset();
+      const offset = {
+        top: $button[0].offsetTop,
+        left: $button[0].offsetLeft
+      };
 
       this.$el.css({
         top: offset.top + $button.outerHeight(),

--- a/src/js/ui/popupAddHeading.js
+++ b/src/js/ui/popupAddHeading.js
@@ -82,14 +82,13 @@ class PopupAddHeading extends LayerPopup {
     this._eventManager.listen('closeAllPopup', this.hide.bind(this));
     this._eventManager.listen('openHeadingSelect', () => {
       const $button = this._$button;
-      const offset = {
-        top: $button[0].offsetTop,
-        left: $button[0].offsetLeft
-      };
-
+      const {
+        offsetTop,
+        offsetLeft
+      } = $button.get(0);
       this.$el.css({
-        top: offset.top + $button.outerHeight(),
-        left: offset.left
+        top: offsetTop + $button.outerHeight(),
+        left: offsetLeft
       });
 
       this._eventManager.emit('closeAllPopup');

--- a/src/js/ui/popupAddTable.js
+++ b/src/js/ui/popupAddTable.js
@@ -141,14 +141,13 @@ class PopupAddTable extends LayerPopup {
 
     this._eventManager.listen('openPopupAddTable', () => {
       const $button = this._$button;
-      const offset = {
-        top: $button[0].offsetTop,
-        left: $button[0].offsetLeft
-      };
-
+      const {
+        offsetTop,
+        offsetLeft
+      } = $button.get(0);
       this.$el.css({
-        top: offset.top + $button.outerHeight(),
-        left: offset.left
+        top: offsetTop + $button.outerHeight(),
+        left: offsetLeft
       });
       this._eventManager.emit('closeAllPopup');
       this.show();

--- a/src/js/ui/popupAddTable.js
+++ b/src/js/ui/popupAddTable.js
@@ -141,7 +141,11 @@ class PopupAddTable extends LayerPopup {
 
     this._eventManager.listen('openPopupAddTable', () => {
       const $button = this._$button;
-      const offset = $button.offset();
+      const offset = {
+        top: $button[0].offsetTop,
+        left: $button[0].offsetLeft
+      };
+
       this.$el.css({
         top: offset.top + $button.outerHeight(),
         left: offset.left


### PR DESCRIPTION
I can't seem to be able to reopen https://github.com/nhnent/tui.editor/pull/195, this is a continuation of that PR that makes popups be children of the toolbar (I tried absolutely positioning the toolbar and both headings and table popups work correctly).

If you have any other issues with this PR, please don't close it so I can resolve them. I will try my best to see this fixed in the end :)