### PR TITLE
fix: error when removing 2nd list item (close #241)

### DIFF
--- a/src/js/wwListManager.js
+++ b/src/js/wwListManager.js
@@ -231,16 +231,33 @@ class WwListManager {
     let nestedList = wrapperDiv.querySelector(NESTED_LIST_QUERY);
     while (nestedList !== null) {
       let prevLI = nestedList.previousElementSibling;
-      while (prevLI.tagName !== 'LI') {
+      while (prevLI && prevLI.tagName !== 'LI') {
         prevLI = prevLI.previousElementSibling;
       }
 
-      prevLI.appendChild(nestedList);
+      if (prevLI) {
+        prevLI.appendChild(nestedList);
+      } else {
+        this._unwrap(nestedList);
+      }
 
       nestedList = wrapperDiv.querySelector(NESTED_LIST_QUERY);
     }
 
     return wrapperDiv.innerHTML;
+  }
+
+  /**
+   * unwrap nesting list
+   * @param {Node} nestedList - nested list to unwrap
+   * @private
+   */
+  _unwrap(nestedList) {
+    const fragment = document.createDocumentFragment();
+    while (nestedList.firstChild) {
+      fragment.appendChild(nestedList.firstChild);
+    }
+    nestedList.parentNode.replaceChild(fragment, nestedList);
   }
 
   /**

--- a/test/unit/wwListManager.spec.js
+++ b/test/unit/wwListManager.spec.js
@@ -52,7 +52,8 @@ describe('WwListManager', () => {
         '</ul>',
         '<ol>',
         '<li><div>me too!</div></li>',
-        '</ol>'].join(''));
+        '</ol>'
+      ].join(''));
 
       expect(wwe.get$Body().find('ul').length).toEqual(1);
       expect(wwe.get$Body().find('ol').length).toEqual(1);
@@ -114,7 +115,8 @@ describe('WwListManager', () => {
         '<li><div>t5</div></li>',
         '</ul>',
         '</li>',
-        '</ul>'].join(''));
+        '</ul>'
+      ].join(''));
       mgr._removeBranchListAll();
 
       expect(wwe.get$Body().find('ul').length).toEqual(3);
@@ -136,7 +138,8 @@ describe('WwListManager', () => {
         '</li>',
         '<li><div>t2</div></li>',
         '</ul>',
-        '</div>'].join(''));
+        '</div>'
+      ].join(''));
 
       mgr._removeBranchListAll();
 
@@ -155,7 +158,8 @@ describe('WwListManager', () => {
         '<li><div>t4<br></div></li>',
         '</ul>',
         '</li>',
-        '</ul>'].join(''));
+        '</ul>'
+      ].join(''));
       mgr._removeBranchListAll();
 
       expect(wwe.get$Body().find('ul').length).toEqual(2);
@@ -215,6 +219,26 @@ describe('WwListManager', () => {
 
       expect(result.indexOf(':BLANK_LINE:')).not.toBe(-1);
       expect(result.indexOf('<br />')).toBe(-1);
+    });
+  });
+
+  describe('_unwrap', () => {
+    it('should unwrap itself and preserve the children', () => {
+      const arbitraryNestingList = $(`
+        <ul id="first">
+          <ul id="second">
+            <li>arbitrary nesting list item</li>
+            <li>arbitrary nesting list item</li>
+          </ul>
+        </ul>`).get(0);
+
+      mgr._unwrap(arbitraryNestingList.querySelector('ul ul'));
+
+      // <ul id="first">
+      //   <li>arbitrary nesting list item</li>
+      //   <li>arbitrary nesting list item</li>
+      // </ul>
+      expect(arbitraryNestingList.querySelector('ul ul')).toBeFalsy();
     });
   });
 


### PR DESCRIPTION
- it produce a arbitrary nesting list we can not process
- unwrap arbitrary nesting list

<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description
#241 


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
