### PR TITLE
fix: click button while IME composition make wrong caret (close #255)

### DIFF
--- a/src/js/wysiwygEditor.js
+++ b/src/js/wysiwygEditor.js
@@ -399,6 +399,7 @@ class WysiwygEditor {
     });
 
     squire.addEventListener('blur', () => {
+      this.fixIMERange();
       this.eventManager.emit('blur', {
         source: 'wysiwyg'
       });
@@ -1084,6 +1085,39 @@ class WysiwygEditor {
    */
   getRange() {
     return this.getEditor().getSelection().cloneRange();
+  }
+
+  /**
+   * get IME range
+   * cjk composition causes wrong caret position.
+   * it returns fixed IME composition range
+   * @memberof WysiwygEditor
+   * @returns {Range}
+   */
+  getIMERange() {
+    let range;
+    const selection = getSelection();
+
+    if (selection && selection.rangeCount) {
+      range = selection.getRangeAt(0).cloneRange();
+    }
+
+    return range;
+  }
+
+  /**
+   * get IME range
+   * cjk composition causes wrong caret position.
+   * it sets fixed IME composition range
+   * @memberof WysiwygEditor
+   */
+  fixIMERange() {
+    const range = this.getIMERange();
+
+    // range exists and it's an WYSIWYG editor content
+    if (range && $(range.commonAncestorContainer).closest(this.$editorContainerEl).length) {
+      this.setRange(range);
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description
#255

CJK IME Composition 도중 툴바 버튼 클릭(blur 일어남) 하면 커서가 composition도중인 포지션 앞으로 위치하여 일어나는 문제로 파악됨.

컴포지션 일어나는 시기에
- squire.getSelection: 컴포지션 중인 문자 앞의 위치를 반환
- window.getSelection: 컴포지션 중인 문자 뒤의 위치를 반환

blur 일어나는 경우(툴바 버튼 클릭 포함) 컴포지션 캐릭터 뒤로 커서 옮기도록 수정.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
