### PR TITLE
fix: additional blank line in codeblock breaks chart (close #81)

### DIFF
--- a/src/js/wwCodeBlockManager.js
+++ b/src/js/wwCodeBlockManager.js
@@ -38,6 +38,7 @@ class WwCodeBlockManager {
 
     this._init();
   }
+
   /**
    * _init
    * Initialize
@@ -147,7 +148,7 @@ class WwCodeBlockManager {
    */
   _mergeCodeblockEachlinesFromHTMLText(html) {
     html = html.replace(/<pre( .*?)?>(.*?)<\/pre>/g, (match, codeAttr, code) => {
-      code = code.replace(/<br \/>/g, '\n');
+      code = code.replace(/<br\s*\/?>/g, '\n');
       code = code.replace(/<div ?(.*?)>/g, '');
       code = code.replace(/\n$/, '');
 

--- a/test/unit/wwCodeBlockManager.spec.js
+++ b/test/unit/wwCodeBlockManager.spec.js
@@ -30,7 +30,7 @@ describe('WwCodeBlockManager', () => {
   // we need to wait squire input event process
   afterEach(done => {
     setTimeout(() => {
-      $('body').empty();
+      $container.remove();
       done();
     });
   });
@@ -212,6 +212,19 @@ describe('WwCodeBlockManager', () => {
       expect(wwe.getValue()).toEqual([
         '<pre><code class="lang-javascript" data-language="javascript">test1\ntest2</code></pre>',
         '<pre><code class="lang-javascript" data-language="javascript">test3\ntest4</code></pre>'
+      ].join(''));
+    });
+
+    it('should replace br to newline on wysiwygProcessHTMLText', () => {
+      wwe.getEditor().setHTML([
+        '<pre class="lang-javascript" data-language="javascript">',
+        'test1<br>',
+        'test2<br />',
+        '</pre>'
+      ].join(''));
+
+      expect(wwe.getValue()).toEqual([
+        '<pre><code class="lang-javascript" data-language="javascript">test1\ntest2</code></pre>'
       ].join(''));
     });
   });


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description
#81


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
