### PR TITLE
Fix: Bundle dependencies (fix #53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ You can use the CDN as below.
 <link rel="stylesheet" href="https://uicdn.toast.com/tui-editor/latest/tui-editor.css"></link>
 <link rel="stylesheet" href="https://uicdn.toast.com/tui-editor/latest/tui-editor-contents.css"></link>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.39.2/codemirror.css"></link>
-<script src="https://uicdn.toast.com/tui-editor/latest/tui-editor-Editor-deps.js"></script>
+<script src="https://uicdn.toast.com/tui-editor/latest/tui-editor-Editor-full.js"></script>
 ```
 
 If you want to use a specific version, use the tag name instead of `latest` in the url's path.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ TOAST UI products are available over the CDN powered by [TOAST Cloud](https://ww
 You can use the CDN as below.
 
 ```html
-<script src="https://uicdn.toast.com/tui-editor/latest/tui-editor-Editor.js"></script>
+<link rel="stylesheet" href="https://uicdn.toast.com/tui-editor/latest/tui-editor.css"></link>
+<link rel="stylesheet" href="https://uicdn.toast.com/tui-editor/latest/tui-editor-contents.css"></link>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.39.2/codemirror.css"></link>
+<script src="https://uicdn.toast.com/tui-editor/latest/tui-editor-Editor-deps.js"></script>
 ```
 
 If you want to use a specific version, use the tag name instead of `latest` in the url's path.
@@ -156,6 +159,16 @@ var editor = new Editor({
 or you can use jquery plugin.
 ```javascript
 $('#editSection').tuiEditor({
+    initialEditType: 'markdown',
+    previewStyle: 'vertical',
+    height: '300px'
+});
+```
+
+or if using the CDN
+```javascript
+var editor = new tui.Editor({
+    el: document.querySelector('#editSection'),
     initialEditType: 'markdown',
     previewStyle: 'vertical',
     height: '300px'

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,7 @@ const BANNER = [
   `@license ${pkg.license}`
 ].join('\n');
 
-const defaultConfigs = Array(isDevServer ? 1 : 4).fill(0).map(() => {
+const defaultConfigs = Array(isDevServer ? 1 : 5).fill(0).map(() => {
   return {
     cache: false,
     output: {
@@ -263,6 +263,21 @@ if (isDevServer) {
   defaultConfigs[3].output.libraryTarget = 'umd';
   if (isProduction) {
     defaultConfigs[3].plugins.push(new BundleAnalyzerPlugin({
+      analyzerMode: 'static',
+      reportFilename: `${ANALYZER_DIR}/stats-${pkg.version}.html`
+    }));
+  }
+
+  // Build with Deps
+  defaultConfigs[4].entry = {
+    'Editor-deps': ENTRY_MAIN,
+    'Viewer-deps': ENTRY_VIEWER
+  };
+  defaultConfigs[4].externals.length = 0;
+  defaultConfigs[4].output.library = NAME_SPACE;
+  defaultConfigs[4].output.libraryTarget = 'umd';
+  if (isProduction) {
+    defaultConfigs[4].plugins.push(new BundleAnalyzerPlugin({
       analyzerMode: 'static',
       reportFilename: `${ANALYZER_DIR}/stats-${pkg.version}.html`
     }));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -270,8 +270,8 @@ if (isDevServer) {
 
   // Build with Deps
   defaultConfigs[4].entry = {
-    'Editor-deps': ENTRY_MAIN,
-    'Viewer-deps': ENTRY_VIEWER
+    'Editor-full': ENTRY_MAIN,
+    'Viewer-full': ENTRY_VIEWER
   };
   defaultConfigs[4].externals.length = 0;
   defaultConfigs[4].output.library = NAME_SPACE;


### PR DESCRIPTION
Fix: CDN and raw `tui-editor-Editor.js` are pretty useless without dependencies. (fix #53, #271)

This PR adds a configuration which doesn't exclude required dependencies from the bundle in a new file `tui-editor-Editor-deps.js`.

The documentation has also been updated to be less mystical about how to get the editor running on your page.