### PR TITLE
docs: give unity

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Place a `<div></div>` where you want TOAST UI Editor rendered.
 Add dependencies & initialize Editor class with given element to make an Editor.
 ```javascript
 // deps for editor
-require('codemirror/lib/codemirror.css') // codemirror
+require('codemirror/lib/codemirror.css'); // codemirror
 require('tui-editor/dist/tui-editor.css'); // editor ui
 require('tui-editor/dist/tui-editor-contents.css'); // editor content
 require('highlight.js/styles/github.css'); // code block highlight


### PR DESCRIPTION
add semicolon for unity

![image](https://user-images.githubusercontent.com/25674959/44450931-35229c80-a62d-11e8-81a5-567474f6b61f.png)

more pretty. 

it's better than nothing. 

At least, that's my opinion. :)


