### PR TITLE
feat: export markdown-it instance without code highlight

### DIFF
--- a/src/js/convertor.js
+++ b/src/js/convertor.js
@@ -245,6 +245,16 @@ class Convertor {
   static getMarkdownitHighlightRenderer() {
     return markdownitHighlight;
   }
+
+  /**
+   * get markdownit
+   * @returns {markdownit} - markdownit instance
+   * @memberof Convertor
+   * @static
+   */
+  static getMarkdownitRenderer() {
+    return markdownit;
+  }
 }
 
 export default Convertor;

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -850,4 +850,10 @@ ToastUIEditor.CommandManager = CommandManager;
  */
 ToastUIEditor.markdownitHighlight = Convertor.getMarkdownitHighlightRenderer();
 
+/**
+ * MarkdownIt instance
+ * @type {MarkdownIt}
+ */
+ToastUIEditor.markdownit = Convertor.getMarkdownitRenderer();
+
 module.exports = ToastUIEditor;

--- a/src/js/viewer.js
+++ b/src/js/viewer.js
@@ -218,6 +218,12 @@ ToastUIEditorViewer.codeBlockManager = codeBlockManager;
 ToastUIEditorViewer.markdownitHighlight = Convertor.getMarkdownitHighlightRenderer();
 
 /**
+ * MarkdownIt instance
+ * @type {MarkdownIt}
+ */
+ToastUIEditorViewer.markdownit = Convertor.getMarkdownitRenderer();
+
+/**
  * @ignore
  */
 ToastUIEditorViewer.i18n = null;


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

The editor exports `ToastUIEditor.markdownitHighlight` so others can extend the markdown rendering behaviour. However the secondary markdown-it instance which is used in `convertor.js: _markdownToHtml(markdown)`  is not exported. It was therefore impossible to extend the markdownToHtml behaviour.

This PR uses the same approach as used for `ToastUIEditor.markdownitHighlight` to export `ToastUIEditor.markdownit` as well.