### PR TITLE
Feat: add "placeholder" support in Markdown and WYSIWYG mode (fix #117)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -50,6 +50,7 @@ declare namespace tuiEditor {
     hideModeSwitch?: boolean;
     exts?: string[];
     customConvertor?: IConvertor;
+    placeholder?: string;
   }
 
   interface IViewerOptions {

--- a/src/css/tui-editor-contents.css
+++ b/src/css/tui-editor-contents.css
@@ -237,3 +237,9 @@
     margin-right: 3.8px;
     margin-top: 3px;
 }
+
+.tui-editor-contents-placeholder:not(:focus):before {
+    content: attr(data-placeholder);
+    color:grey;
+    font-style: italic;
+}

--- a/src/css/tui-editor-contents.css
+++ b/src/css/tui-editor-contents.css
@@ -242,4 +242,6 @@
     content: attr(data-placeholder);
     color:grey;
     font-style: italic;
+    line-height: 160%;
+    position: absolute;
 }

--- a/src/css/tui-editor-contents.css
+++ b/src/css/tui-editor-contents.css
@@ -238,10 +238,9 @@
     margin-top: 3px;
 }
 
-.tui-editor-contents-placeholder:not(:focus):before {
+.tui-editor-contents-placeholder:before {
     content: attr(data-placeholder);
     color:grey;
-    font-style: italic;
     line-height: 160%;
     position: absolute;
 }

--- a/src/css/tui-editor.css
+++ b/src/css/tui-editor.css
@@ -183,7 +183,12 @@
 
 .tui-editor-defaultUI .CodeMirror-line {
     padding-left: 25px;
-    padding-right: 25px
+    padding-right: 25px;
+}
+
+.tui-editor-defaultUI .CodeMirror pre.CodeMirror-placeholder {
+    padding-left: 25px;
+    color: grey;
 }
 
 .tui-editor-defaultUI .CodeMirror-scroll {

--- a/src/js/codeMirrorExt.js
+++ b/src/js/codeMirrorExt.js
@@ -11,6 +11,7 @@ import './codemirror/markdown';
 import './codemirror/gfm';
 import './codemirror/continuelist';
 import './codemirror/arrowKeyFunction';
+import './codemirror/placeholder';
 
 /**
  * Class CodeMirrorExt
@@ -224,6 +225,16 @@ class CodeMirrorExt {
     const contentWrapper = this.getWrapperElement();
 
     contentWrapper.style.minHeight = `${minHeight}px`;
+  }
+
+  /**
+   * Set the placeholder to CodeMirror
+   * @param {string} placeholder - placeholder to set
+   */
+  setPlaceholder(placeholder) {
+    if (placeholder) {
+      this.cm.setOption('placeholder', placeholder);
+    }
   }
 
   /**

--- a/src/js/codemirror/placeholder.js
+++ b/src/js/codemirror/placeholder.js
@@ -1,0 +1,62 @@
+// CodeMirror, copyright (c) by Marijn Haverbeke and others
+// Distributed under an MIT license: http://codemirror.net/LICENSE
+/**
+ * @modifier NHN Ent. FE Development Lab <dl_javascript@nhnent.com>
+ */
+import CodeMirror from 'codemirror';
+
+/* eslint-disable */
+CodeMirror.defineOption('placeholder', '', function(cm, val, old) {
+  var prev = old && old != CodeMirror.Init
+  if (val && !prev) {
+    cm.on('blur', onBlur)
+    cm.on('change', onChange)
+    cm.on('swapDoc', onChange)
+    onChange(cm)
+  } else if (!val && prev) {
+    cm.off('blur', onBlur)
+    cm.off('change', onChange)
+    cm.off('swapDoc', onChange)
+    clearPlaceholder(cm)
+    var wrapper = cm.getWrapperElement()
+    wrapper.className = wrapper.className.replace(' CodeMirror-empty', '')
+  }
+
+  if (val && !cm.hasFocus()) onBlur(cm)
+})
+
+function clearPlaceholder(cm) {
+  if (cm.state.placeholder) {
+    cm.state.placeholder.parentNode.removeChild(cm.state.placeholder)
+    cm.state.placeholder = null
+  }
+}
+function setPlaceholder(cm) {
+  clearPlaceholder(cm)
+  var elt = (cm.state.placeholder = document.createElement('pre'))
+  elt.style.cssText = 'height: 0; overflow: visible'
+  elt.className = 'CodeMirror-placeholder'
+  var placeHolder = cm.getOption('placeholder')
+  if (typeof placeHolder == 'string')
+    placeHolder = document.createTextNode(placeHolder)
+  elt.appendChild(placeHolder)
+  cm.display.lineSpace.insertBefore(elt, cm.display.lineSpace.firstChild)
+}
+
+function onBlur(cm) {
+  if (isEmpty(cm)) setPlaceholder(cm)
+}
+function onChange(cm) {
+  var wrapper = cm.getWrapperElement(),
+    empty = isEmpty(cm)
+  wrapper.className =
+    wrapper.className.replace(' CodeMirror-empty', '') +
+    (empty ? ' CodeMirror-empty' : '')
+
+  if (empty) setPlaceholder(cm)
+  else clearPlaceholder(cm)
+}
+
+function isEmpty(cm) {
+  return cm.lineCount() === 1 && cm.getLine(0) === ''
+}

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -217,6 +217,8 @@ class ToastUIEditor {
 
     this.setValue(this.options.initialValue, false);
 
+    this.setPlaceholder(this.options.placeholder);
+
     if (!this.options.initialValue) {
       this.setHtml(this.initialHtml, false);
     }
@@ -769,6 +771,10 @@ class ToastUIEditor {
     const textObject = this.getTextObject(range);
 
     return textObject.getTextContent() || '';
+  }
+
+  setPlaceholder(placeholder) {
+    this.wwEditor.setPlaceholder(placeholder);
   }
 
   /**

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -127,6 +127,7 @@ class ToastUIEditor {
     * @param {boolean} [options.hideModeSwitch=false] - hide mode switch tab bar
     * @param {string[]} [options.exts] - extensions
     * @param {object} [options.customConvertor] - convertor extention
+    * @param {string} [options.placeholder] - The placeholder text of the editable element.
     */
   constructor(options) {
     this.initialHtml = options.el.innerHTML;
@@ -217,7 +218,9 @@ class ToastUIEditor {
 
     this.setValue(this.options.initialValue, false);
 
-    this.setPlaceholder(this.options.placeholder);
+    if (this.options.placeholder) {
+      this.setPlaceholder(this.options.placeholder);
+    }
 
     if (!this.options.initialValue) {
       this.setHtml(this.initialHtml, false);
@@ -773,7 +776,12 @@ class ToastUIEditor {
     return textObject.getTextContent() || '';
   }
 
+  /**
+   * Set the placeholder an all editors
+   * @param {string} placeholder - placeholder to set
+   */
   setPlaceholder(placeholder) {
+    this.mdEditor.setPlaceholder(placeholder);
     this.wwEditor.setPlaceholder(placeholder);
   }
 

--- a/src/js/wysiwygEditor.js
+++ b/src/js/wysiwygEditor.js
@@ -272,6 +272,8 @@ class WysiwygEditor {
       }
 
       this.getEditor().preserveLastLine();
+
+      this._togglePlaceholder();
     }, 0));
 
     squire.addEventListener('keydown', keyboardEvent => {
@@ -342,8 +344,6 @@ class WysiwygEditor {
         source: 'wysiwyg',
         data: keyboardEvent
       });
-
-      this._togglePlaceholder();
     });
 
     this.$editorContainerEl.on('scroll', ev => {

--- a/src/js/wysiwygEditor.js
+++ b/src/js/wysiwygEditor.js
@@ -438,10 +438,11 @@ class WysiwygEditor {
   }
 
   _togglePlaceholder() {
-    if (this.get$Body()[0].textContent === '') {
-      this.get$Body().addClass('tui-editor-contents-placeholder');
+    const $body = this.get$Body();
+    if ($body[0].textContent) {
+      $body.removeClass('tui-editor-contents-placeholder');
     } else {
-      this.get$Body().removeClass('tui-editor-contents-placeholder');
+      $body.addClass('tui-editor-contents-placeholder');
     }
   }
 
@@ -764,6 +765,10 @@ class WysiwygEditor {
     editorBody.style.minHeight = `${minHeight}px`;
   }
 
+  /**
+   * Set the placeholder to wysiwyg editor
+   * @param {string} placeholder - placeholder to set
+   */
   setPlaceholder(placeholder) {
     if (placeholder) {
       this.get$Body()[0].dataset.placeholder = placeholder;

--- a/src/js/wysiwygEditor.js
+++ b/src/js/wysiwygEditor.js
@@ -82,6 +82,7 @@ class WysiwygEditor {
 
     this.get$Body().addClass(EDITOR_CONTENT_CSS_CLASSNAME);
     this.$editorContainerEl.css('position', 'relative');
+    this._togglePlaceholder();
 
     this.codeBlockGadget = new CodeBlockGadget({
       eventManager: this.eventManager,
@@ -341,6 +342,8 @@ class WysiwygEditor {
         source: 'wysiwyg',
         data: keyboardEvent
       });
+
+      this._togglePlaceholder();
     });
 
     this.$editorContainerEl.on('scroll', ev => {
@@ -432,6 +435,14 @@ class WysiwygEditor {
         });
       }
     });
+  }
+
+  _togglePlaceholder() {
+    if (this.get$Body()[0].textContent === '') {
+      this.get$Body().addClass('tui-editor-contents-placeholder');
+    } else {
+      this.get$Body().removeClass('tui-editor-contents-placeholder');
+    }
   }
 
   /**
@@ -753,6 +764,12 @@ class WysiwygEditor {
     editorBody.style.minHeight = `${minHeight}px`;
   }
 
+  setPlaceholder(placeholder) {
+    if (placeholder) {
+      this.get$Body()[0].dataset.placeholder = placeholder;
+    }
+  }
+
   /**
    * setValue
    * Set value to wysiwyg editor
@@ -776,6 +793,8 @@ class WysiwygEditor {
 
     this.getEditor().removeLastUndoStack();
     this.getEditor().saveUndoState();
+
+    this._togglePlaceholder();
   }
 
   /**


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] It's the right issue type on the title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

Add support for "placeholder" option in WYSIWYG mode.

Fix #117 

![placeholder](https://user-images.githubusercontent.com/7514993/51427259-2afcce00-1bcc-11e9-942c-6bc223e213d7.gif)

---

Before I spend time adding tests, updating documentation, JSDoc, doing more proper manual regressions tests, etc. I would like to know if this a contribution that you would accept and are willing to review and work together with me to get done.

I volunteer some of my own time to implement this properly since I could use this feature and would prefer it to be supported natively than hacking it on my own in my consuming application.

If the answer is positive, then I'd like to know how you feel about this approach, if the location of the code aligns with the rest of the structure and architecture, and of course any general suggestions you might have.

And by the way, this is a great and solid editor! Congratulations to you and whole team of contributors for working on it and putting it out there for the community to use! You have my gratitude! 🎉 👍 	
