### PR TITLE
fix: undo stack is incorrect in wysiwyg (close #381)

### DIFF
--- a/src/js/wysiwygEditor.js
+++ b/src/js/wysiwygEditor.js
@@ -444,10 +444,8 @@ class WysiwygEditor {
     squire.modifyDocument(() => {
       const root = squire.getRoot();
       if (root.textContent || root.childNodes.length > 1) {
-        if (root.classList.contains(PLACEHOLDER_CSS_CLASSNAME)) {
-          root.classList.remove(PLACEHOLDER_CSS_CLASSNAME);
-        }
-      } else if (!root.classList.contains(PLACEHOLDER_CSS_CLASSNAME)) {
+        root.classList.remove(PLACEHOLDER_CSS_CLASSNAME);
+      } else {
         root.classList.add(PLACEHOLDER_CSS_CLASSNAME);
       }
     });

--- a/src/js/wysiwygEditor.js
+++ b/src/js/wysiwygEditor.js
@@ -28,6 +28,7 @@ const FIND_EMPTY_LINE = /<([a-z]+|h\d)>(<br>|<br \/>)<\/\1>/gi,
   FIND_BLOCK_TAGNAME_RX = /\b(H[\d]|LI|P|BLOCKQUOTE|TD|PRE)\b/;
 
 const EDITOR_CONTENT_CSS_CLASSNAME = 'tui-editor-contents';
+const PLACEHOLDER_CSS_CLASSNAME = 'tui-editor-contents-placeholder';
 
 const canObserveMutations = (typeof MutationObserver !== 'undefined');
 
@@ -113,6 +114,9 @@ class WysiwygEditor {
     this.eventManager.listen('wysiwygSetValueBefore', html => this._preprocessForInlineElement(html));
     this.eventManager.listen('wysiwygKeyEvent', ev => this._runKeyEventHandlers(ev.data, ev.keyMap));
     this.eventManager.listen('wysiwygRangeChangeAfter', () => this.scrollIntoCursor());
+    this.eventManager.listen('contentChangedFromWysiwyg', () => {
+      this._togglePlaceholder();
+    });
   }
 
   /**
@@ -272,8 +276,6 @@ class WysiwygEditor {
       }
 
       this.getEditor().preserveLastLine();
-
-      this._togglePlaceholder();
     }, 0));
 
     squire.addEventListener('keydown', keyboardEvent => {
@@ -438,12 +440,17 @@ class WysiwygEditor {
   }
 
   _togglePlaceholder() {
-    const $body = this.get$Body();
-    if ($body[0].textContent) {
-      $body.removeClass('tui-editor-contents-placeholder');
-    } else {
-      $body.addClass('tui-editor-contents-placeholder');
-    }
+    const squire = this.getEditor();
+    squire.modifyDocument(() => {
+      const root = squire.getRoot();
+      if (root.textContent || root.childNodes.length > 1) {
+        if (root.classList.contains(PLACEHOLDER_CSS_CLASSNAME)) {
+          root.classList.remove(PLACEHOLDER_CSS_CLASSNAME);
+        }
+      } else if (!root.classList.contains(PLACEHOLDER_CSS_CLASSNAME)) {
+        root.classList.add(PLACEHOLDER_CSS_CLASSNAME);
+      }
+    });
   }
 
   /**
@@ -771,7 +778,7 @@ class WysiwygEditor {
    */
   setPlaceholder(placeholder) {
     if (placeholder) {
-      this.get$Body()[0].dataset.placeholder = placeholder;
+      this.getEditor().getRoot().setAttribute('data-placeholder', placeholder);
     }
   }
 
@@ -798,8 +805,6 @@ class WysiwygEditor {
 
     this.getEditor().removeLastUndoStack();
     this.getEditor().saveUndoState();
-
-    this._togglePlaceholder();
   }
 
   /**


### PR DESCRIPTION

<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

If placeholder class(`tui-editor-contents-placeholder`) is changed during undo, `_docWasChanged` of Squire occurs. So undostate change `false` and redo does not work.
`modifyDocument` of squire does not change undostate, so should use `modifyDocument` when change placeholder class.
(issue : #381)

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
