### PR TITLE
fix: list `TAP` issue on wysiwig editor (close #407)

### DIFF
--- a/src/js/wwListManager.js
+++ b/src/js/wwListManager.js
@@ -74,16 +74,14 @@ class WwListManager {
   }
 
   _initKeyHandler() {
-    this.wwe.addKeyEventHandler(['TAB', 'CTRL+]', 'META+]'], (ev, range) => {
+    this.wwe.addKeyEventHandler(['TAB', 'CTRL+]', 'META+]'], (ev) => {
       let isNeedNext;
 
-      if (range.collapsed) {
-        if (this.wwe.getEditor().hasFormat('LI')) {
-          ev.preventDefault();
-          this.eventManager.emit('command', 'Indent');
+      if (this.wwe.getEditor().hasFormat('LI')) {
+        ev.preventDefault();
+        this.eventManager.emit('command', 'Indent');
 
-          isNeedNext = false;
-        }
+        isNeedNext = false;
       }
 
       return isNeedNext;
@@ -92,19 +90,17 @@ class WwListManager {
     this.wwe.addKeyEventHandler(['SHIFT+TAB', 'CTRL+[', 'META+['], (ev, range) => {
       let isNeedNext;
 
-      if (range.collapsed) {
-        if (this.wwe.getEditor().hasFormat('LI')) {
-          ev.preventDefault();
-          const $ul = $(range.startContainer).closest('li').children(UL_OR_OL);
+      if (this.wwe.getEditor().hasFormat('LI')) {
+        ev.preventDefault();
+        const $ul = $(range.startContainer).closest('li').children(UL_OR_OL);
 
-          this.eventManager.emit('command', 'Outdent');
+        this.eventManager.emit('command', 'Outdent');
 
-          if ($ul.length && !$ul.prev().length) {
-            this._removeBranchList($ul);
-          }
-
-          isNeedNext = false;
+        if ($ul.length && !$ul.prev().length) {
+          this._removeBranchList($ul);
         }
+
+        isNeedNext = false;
       }
 
       return isNeedNext;


### PR DESCRIPTION
fix: 위지윅 모드에서 범위를 지정 후 탭을 눌렀을 때 동작하지 않음(ref #407)

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has a description of the breaking change

### Description
조금 디버깅해봤어요, `collapsed` 가 아무래도 코드미러에서 온 것으로 보이는데 범위 선택을 하면 `collapsed: false` 가 들어옵니다.
이때 `wwListManager.js` 의 `TAB` 핸들러 부분에서 `if` 처리가 되어 있어 함께 돌지 못하는 것으로 보입니다. 사이드 이펙트나 테스트 룰을 몰라 `PR`은 참조 용으로 봐주세요.



---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
