### PR TITLE
Prevent 'zh_TW' cover 'zh_CN'

### DIFF
--- a/src/js/langs/zh_CN.js
+++ b/src/js/langs/zh_CN.js
@@ -4,7 +4,7 @@
 */
 import i18n from '../i18n';
 
-i18n.setLanguage(['zh', 'zh_CN'], {
+i18n.setLanguage(['zhcn', 'zh_CN'], {
   'Markdown': 'Markdown',
   'WYSIWYG': '所见即所得',
   'Write': '编辑',


### PR DESCRIPTION
To prevent 'zh_TW' covering 'zh_CN' config.
'zh_TW' and  'zh_CN' have the same key 'zh'.
Whatever you set 'zh_CN' or 'zh' config, 
It will be 'zh_TW' language.
