### PR TITLE
fix: To prevent 'zh_TW' covering 'zh_CN' config. (close:  #418)

### DIFF
--- a/src/js/langs/zh_TW.js
+++ b/src/js/langs/zh_TW.js
@@ -4,7 +4,7 @@
 */
 import i18n from '../i18n';
 
-i18n.setLanguage(['zh', 'zh_TW'], {
+i18n.setLanguage(['zhtw', 'zh_TW'], {
   'Markdown': 'Markdown',
   'WYSIWYG': '所見即所得',
   'Write': '編輯',


### PR DESCRIPTION
To prevent 'zh_TW' covering 'zh_CN' config.
'zh_TW' and  'zh_CN' have the same key 'zh'.
Whatever you set 'zh_CN' or 'zh' config, 
It will be 'zh_TW' language.
