### PR TITLE
fix: rendering long contents when height is auto (close: #410)

### DIFF
--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -204,7 +204,7 @@ class ToastUIEditor {
 
     this.setUI(this.options.UI || new DefaultUI(this));
 
-    this.mdEditor = MarkdownEditor.factory(this.layout.getMdEditorContainerEl(), this.eventManager);
+    this.mdEditor = MarkdownEditor.factory(this.layout.getMdEditorContainerEl(), this.eventManager, this.options);
     this.preview = new MarkdownPreview(this.layout.getPreviewEl(), this.eventManager, this.convertor);
     this.wwEditor = WysiwygEditor.factory(this.layout.getWwEditorContainerEl(), this.eventManager);
     this.toMarkOptions = null;

--- a/src/js/markdownEditor.js
+++ b/src/js/markdownEditor.js
@@ -20,9 +20,10 @@ class MarkdownEditor extends CodeMirrorExt {
    * Creates an instance of MarkdownEditor.
    * @param {jQuery} $el - container jquery element
    * @param {EventManager} eventManager - event manager
+   * @param {Object} options - options of editor
    * @memberof MarkdownEditor
    */
-  constructor($el, eventManager) {
+  constructor($el, eventManager, options) {
     super($el.get(0), {
       mode: 'gfm',
       dragDrop: true,
@@ -31,7 +32,8 @@ class MarkdownEditor extends CodeMirrorExt {
         'Enter': 'newlineAndIndentContinueMarkdownList',
         'Tab': 'indentOrderedList',
         'Shift-Tab': 'indentLessOrderedList'
-      }
+      },
+      viewportMargin: options.height === 'auto' ? Infinity : 10
     });
     this.eventManager = eventManager;
     this.componentManager = new ComponentManager(this);
@@ -246,10 +248,11 @@ class MarkdownEditor extends CodeMirrorExt {
    * @memberof MarkdownEditor
    * @param {jQuery} $el - Container element for editor
    * @param {EventManager} eventManager - EventManager instance
+   * @param {Object} options - options of editor
    * @returns {MarkdownEditor} - MarkdownEditor
    */
-  static factory($el, eventManager) {
-    const mde = new MarkdownEditor($el, eventManager);
+  static factory($el, eventManager, options) {
+    const mde = new MarkdownEditor($el, eventManager, options);
 
     return mde;
   }


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description
fix #410 

CodeMirror auto resize need option that is `viewportMargin: Infinity`.

https://codemirror.net/demo/resize.html


---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
