### PR TITLE
fix: tag escaped when switching from markdown to wysiwyg (fix: #300)

### DIFF
--- a/src/js/wwCodeBlockManager.js
+++ b/src/js/wwCodeBlockManager.js
@@ -207,7 +207,7 @@ class WwCodeBlockManager {
 
       const resultText = $pre.text().replace(/\s+$/, '');
       $pre.empty();
-      $pre.html(resultText ? resultText : brString);
+      $pre.html(resultText ? sanitizeHtmlCode(resultText) : brString);
 
       if (lang) {
         $pre.attr('data-language', lang);

--- a/test/unit/wwCodeBlockManager.spec.js
+++ b/test/unit/wwCodeBlockManager.spec.js
@@ -306,5 +306,19 @@ describe('WwCodeBlockManager', () => {
 
       expect(codeblock.split('\n').length).toEqual(3);
     });
+
+    it('keep tag text in the pre tag', () => {
+      const frag = document.createDocumentFragment();
+      $(frag).append('<pre></pre>');
+
+      const preTag = $(frag).find('pre');
+      preTag.text('<span>test</span>');
+
+      mgr.modifyCodeBlockForWysiwyg(frag);
+
+      const codeblockText = $($(frag).find('pre')).text();
+
+      expect(codeblockText).toEqual('<span>test</span>');
+    });
   });
 });

--- a/test/unit/wwCodeBlockManager.spec.js
+++ b/test/unit/wwCodeBlockManager.spec.js
@@ -247,7 +247,7 @@ describe('WwCodeBlockManager', () => {
 
       mgr.modifyCodeBlockForWysiwyg(frag);
 
-      const codeblock = $($(frag).find('pre'));
+      const codeblock = $(frag).find('pre');
 
       expect(codeblock.length).toEqual(1);
       expect(codeblock.hasClass('lang-javascript')).toBe(true);
@@ -261,7 +261,7 @@ describe('WwCodeBlockManager', () => {
 
       mgr.modifyCodeBlockForWysiwyg(frag);
 
-      const codeblock = $($(frag).find('pre'));
+      const codeblock = $(frag).find('pre');
       expect(codeblock.attr('data-backticks')).toEqual('4');
     });
 
@@ -273,7 +273,7 @@ describe('WwCodeBlockManager', () => {
 
       mgr.modifyCodeBlockForWysiwyg(frag);
 
-      const codeblock = $($(frag).find('pre')).text();
+      const codeblock = $(frag).find('pre').text();
 
       expect(codeblock.split('\n').length).toEqual(3);
     });
@@ -286,7 +286,7 @@ describe('WwCodeBlockManager', () => {
 
       mgr.modifyCodeBlockForWysiwyg(frag);
 
-      const codeblock = $($(frag).find('pre')).text();
+      const codeblock = $(frag).find('pre').text();
 
       expect(codeblock.split('\n').length).toEqual(4);
     });
@@ -302,7 +302,7 @@ describe('WwCodeBlockManager', () => {
 
       mgr.modifyCodeBlockForWysiwyg(frag);
 
-      const codeblock = $($(frag).find('pre')).text();
+      const codeblock = $(frag).find('pre').text();
 
       expect(codeblock.split('\n').length).toEqual(3);
     });
@@ -316,7 +316,7 @@ describe('WwCodeBlockManager', () => {
 
       mgr.modifyCodeBlockForWysiwyg(frag);
 
-      const codeblockText = $($(frag).find('pre')).text();
+      const codeblockText = $(frag).find('pre').text();
 
       expect(codeblockText).toEqual('<span>test</span>');
     });


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

When a html tag text is in the codeblock of the markdown, it disappear if convert to Wysiwyg.

마크다운 모드에서 코드블럭에 html 테그를 작성하면 위지윅으로 변환 시에 작성한 html 테그가 사라지는 문제를 수정한 것입니다.
이전에 스콰이어 버전 update시 codeblock의 개행처리 방식이 바껴서 수정하는 과정 중 html 테그 문자열을 html entities로 바꾸는 부분이 누락되었습니다.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
