### PR TITLE
feat: use :before as clickable task area (close #436)

### DIFF
--- a/src/css/tui-editor-contents.css
+++ b/src/css/tui-editor-contents.css
@@ -226,7 +226,7 @@
 .tui-editor-contents .task-list-item:before {
     background-repeat: no-repeat;
     background-size: 16px 16px;
-    background-position: 50%;
+    background-position: center;
     content: "";
     height: 18px;
     width: 18px;

--- a/src/css/tui-editor-contents.css
+++ b/src/css/tui-editor-contents.css
@@ -223,7 +223,7 @@
     margin-left: -22px;
 }
 
-.tui-editor-contents ul li.task-list-item:before {
+.tui-editor-contents .task-list-item:before {
     background-repeat: no-repeat;
     background-size: 16px 16px;
     background-position: 50%;
@@ -232,7 +232,8 @@
     width: 18px;
     position: absolute;
     left: 0;
-    top: 2px;
+    top: 1px;
+    cursor: pointer;
     background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAAXNSR0IArs4c6QAAADdJREFUKBVjvHv37n8GMgALSI+SkhJJWu/du8fARJIOJMWjGpECA505GjjoIYLEB6dVUNojFQAA/1MJUFWet/4AAAAASUVORK5CYII=');
 }
 

--- a/src/css/tui-editor-contents.css
+++ b/src/css/tui-editor-contents.css
@@ -221,13 +221,22 @@
     list-style: none;
     padding-left: 22px;
     margin-left: -22px;
+}
+
+.tui-editor-contents ul li.task-list-item:before {
     background-repeat: no-repeat;
     background-size: 16px 16px;
-    background-position: 0 2px;
+    background-position: 50%;
+    content: "";
+    height: 18px;
+    width: 18px;
+    position: absolute;
+    left: 0;
+    top: 2px;
     background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAAXNSR0IArs4c6QAAADdJREFUKBVjvHv37n8GMgALSI+SkhJJWu/du8fARJIOJMWjGpECA505GjjoIYLEB6dVUNojFQAA/1MJUFWet/4AAAAASUVORK5CYII=');
 }
 
-.tui-editor-contents .task-list-item.checked {
+.tui-editor-contents .task-list-item.checked:before {
     background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAAXNSR0IArs4c6QAAAMpJREFUKBVjjJ/64D8DGYCJDD1gLbTVyM3OxJDiJMzAxcYIdyALnIWDAdJU7i/OICfCxsDMxMgwc88bwk5F1vTs/W+GFUffwY2H+1FBlI2hLliCQYCbGSyJrqlzwwuGj9//YWoMtRBgUBJnZ6gMEGeQFWaFOw9kE7omkG5GWDyCPF7mJ86gIMbO8P//fwZGRkYGXJpAGuFO/fbrP0PXppcMD179JKgJRSOIA9N8/NZXrM4DqYEBjOgAaYYFOUwRNhruVGyS+MTI1ggAx8NTGcUtFVQAAAAASUVORK5CYII=');
 }
 

--- a/src/js/domUtils.js
+++ b/src/js/domUtils.js
@@ -577,6 +577,27 @@ const getLeafNode = function(node) {
 
   return result;
 };
+/**
+ * check if a coordinates is inside a task box
+ * @param {object} style - computed style of task box
+ * @param {number} offsetX - event x offset
+ * @param {number} offsetY - event y offset
+ * @returns {boolean}
+ * @ignore
+ */
+const isInsideTaskBox = function(style, offsetX, offsetY) {
+  const rect = {
+    left: parseInt(style.left, 10),
+    top: parseInt(style.top, 10),
+    width: parseInt(style.width, 10),
+    height: parseInt(style.height, 10)
+  };
+
+  return offsetX >= rect.left
+    && offsetX <= (rect.left + rect.width)
+    && offsetY >= rect.top
+    && offsetY <= (rect.top + rect.height);
+};
 
 export default {
   getNodeName,
@@ -604,5 +625,6 @@ export default {
   isStyledNode,
   removeChildFromStartToEndNode,
   removeNodesByDirection,
-  getLeafNode
+  getLeafNode,
+  isInsideTaskBox
 };

--- a/src/js/viewer.js
+++ b/src/js/viewer.js
@@ -86,9 +86,20 @@ class ToastUIEditorViewer {
    * @private
    */
   _toggleTask(ev) {
-    const isBeneathTaskBox = ev.offsetX < 18 && ev.offsetY > 18;
+    // Get position of the before element
+    const style = getComputedStyle(ev.target, ':before');
+    const left = parseInt(style.left, 10);
+    const top = parseInt(style.top, 10);
+    const width = parseInt(style.width, 10);
+    const height = parseInt(style.height, 10);
 
-    if (ev.target.hasAttribute(TASK_ATTR_NAME) && !isBeneathTaskBox) {
+    // Check if click is inside the square delimited by the before element
+    const isOnTaskBox = ev.offsetX >= left
+      && ev.offsetX <= (left + width)
+      && ev.offsetY >= top
+      && ev.offsetY <= (top + height);
+
+    if (ev.target.hasAttribute(TASK_ATTR_NAME) && isOnTaskBox) {
       $(ev.target).toggleClass(TASK_CHECKED_CLASS_NAME);
       this.eventManager.emit('change', {
         source: 'viewer',

--- a/src/js/viewer.js
+++ b/src/js/viewer.js
@@ -86,20 +86,9 @@ class ToastUIEditorViewer {
    * @private
    */
   _toggleTask(ev) {
-    // Get position of the before element
     const style = getComputedStyle(ev.target, ':before');
-    const left = parseInt(style.left, 10);
-    const top = parseInt(style.top, 10);
-    const width = parseInt(style.width, 10);
-    const height = parseInt(style.height, 10);
 
-    // Check if click is inside the square delimited by the before element
-    const isOnTaskBox = ev.offsetX >= left
-      && ev.offsetX <= (left + width)
-      && ev.offsetY >= top
-      && ev.offsetY <= (top + height);
-
-    if (ev.target.hasAttribute(TASK_ATTR_NAME) && isOnTaskBox) {
+    if (ev.target.hasAttribute(TASK_ATTR_NAME) && domUtils.isInsideTaskBox(style, ev.offsetX, ev.offsetY)) {
       $(ev.target).toggleClass(TASK_CHECKED_CLASS_NAME);
       this.eventManager.emit('change', {
         source: 'viewer',

--- a/src/js/wwTaskManager.js
+++ b/src/js/wwTaskManager.js
@@ -4,6 +4,8 @@
  */
 import $ from 'jquery';
 
+import domUtils from './domUtils';
+
 const TASK_CLASS_NAME = 'task-list-item';
 const TASK_ATTR_NAME = 'data-te-task';
 const TASK_CHECKED_CLASS_NAME = 'checked';
@@ -42,20 +44,9 @@ class WwTaskManager {
     this._initEvent();
 
     this.wwe.getEditor().addEventListener('mousedown', ev => {
-      // Get position of the before element
       const style = getComputedStyle(ev.target, ':before');
-      const left = parseInt(style.left, 10);
-      const top = parseInt(style.top, 10);
-      const width = parseInt(style.width, 10);
-      const height = parseInt(style.height, 10);
 
-      // Check if click is inside the square delimited by the before element
-      const isOnTaskBox = ev.offsetX >= left
-        && ev.offsetX <= (left + width)
-        && ev.offsetY >= top
-        && ev.offsetY <= (top + height);
-
-      if (ev.target.hasAttribute(TASK_ATTR_NAME) && isOnTaskBox) {
+      if (ev.target.hasAttribute(TASK_ATTR_NAME) && domUtils.isInsideTaskBox(style, ev.offsetX, ev.offsetY)) {
         // Prevent cursor focusing
         ev.preventDefault();
         $(ev.target).toggleClass(TASK_CHECKED_CLASS_NAME);

--- a/src/js/wwTaskManager.js
+++ b/src/js/wwTaskManager.js
@@ -42,9 +42,22 @@ class WwTaskManager {
     this._initEvent();
 
     this.wwe.getEditor().addEventListener('mousedown', ev => {
-      const isOnTaskBox = ev.offsetX < 18 && ev.offsetY < 18;
+      // Get position of the before element
+      const style = getComputedStyle(ev.target, ':before');
+      const left = parseInt(style.left, 10);
+      const top = parseInt(style.top, 10);
+      const width = parseInt(style.width, 10);
+      const height = parseInt(style.height, 10);
+
+      // Check if click is inside the square delimited by the before element
+      const isOnTaskBox = ev.offsetX >= left
+        && ev.offsetX <= (left + width)
+        && ev.offsetY >= top
+        && ev.offsetY <= (top + height);
 
       if (ev.target.hasAttribute(TASK_ATTR_NAME) && isOnTaskBox) {
+        // Prevent cursor focusing
+        ev.preventDefault();
         $(ev.target).toggleClass(TASK_CHECKED_CLASS_NAME);
       }
     });


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

Use the `:before` pseudo-element to detect the clickable area of a task. I decided to not used the line height because it doesn't work properly whith big line height (a part of the task become clickable).
Plus it allow much more customization with CSS.

I also add a `preventDefault` when the click is valid and in the wysiwyg editor, it prevents the cursor of focusing the task which is not useful at this moment and cause the keyboard to appears on mobile.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
